### PR TITLE
Add Qwen 3.5 (4B/9B, Base/Instruct) to supervised_finetuning recipes

### DIFF
--- a/0_model_customization_recipes/supervised_finetuning/finetune--Qwen--Qwen3.5-4B-Base.ipynb
+++ b/0_model_customization_recipes/supervised_finetuning/finetune--Qwen--Qwen3.5-4B-Base.ipynb
@@ -1,0 +1,672 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e60b91a9-7d9c-4c45-be0f-5a224581f644",
+   "metadata": {},
+   "source": [
+    "# \ud83d\ude80 Customize and Deploy `Qwen/Qwen3.5-4B-Base` on Amazon SageMaker AI\n",
+    "---\n",
+    "This notebook fine-tunes **Qwen3.5-4B-Base** (~4 billion) on Amazon SageMaker Training Jobs using the shared `sagemaker_code/sft.py` driver. Both QLoRA (4-bit) and full fine-tuning are supported via the strategy chooser cell.\n",
+    "\n",
+    "\ud83d\udd17 Model card: [Qwen/Qwen3.5-4B-Base on Hugging Face](https://huggingface.co/Qwen/Qwen3.5-4B-Base)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Validated configurations**:\n",
+    "\n",
+    "| Strategy | Default instance | GPU(s) | Wall clock (typical) |\n",
+    "|---|---|---|---|\n",
+    "| QLoRA (4-bit) | `ml.g5.2xlarge` | 1\u00d7 A10G 24 GB | ~20-30 min |\n",
+    "| Full fine-tuning | `ml.g7e.2xlarge` | 1\u00d7 RTX PRO 6000 Blackwell 96 GB | ~30-50 min |\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Why this notebook overrides `sagemaker_code/requirements.txt`**\n",
+    "\n",
+    "Qwen 3.5 introduces a new model architecture (`qwen3_5`) that requires `transformers >= 5.2.0`. The shared `requirements.txt` pins `transformers==4.57.0`, so the cell below overrides the file via `%%writefile` (with a backed-up `.bak`, restored by the final cell):\n",
+    "\n",
+    "| Package | Shared default | Required | Why |\n",
+    "|---|---|---|---|\n",
+    "| `transformers` | 4.57.0 | 5.2.0 | `qwen3_5` architecture not in 4.x |\n",
+    "| `peft` | 0.17.0 | 0.18.1 | `HybridCache` removed in transformers 5.x |\n",
+    "| `bitsandbytes` | 0.46.1 | 0.49.2 | First version with a CUDA 13.0 binary |\n",
+    "| `liger-kernel` | 0.6.1 | 0.7.0 | Same `HybridCache` compatibility issue |\n",
+    "\n",
+    "`trl == 0.21.0` and the rest of the toolchain are unchanged \u2014 Qwen 3.5 works with the existing `sft.py` and `merge_adapter_weights.py` without source-code patches.\n",
+    "\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ce40054-610a-4acc-a546-943893f293c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -Uq \"datasets==4.3.0\" \\\n",
+    "    \"sagemaker==2.253.1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b791e72e-82b5-4f8e-a7fe-700e8afdeba5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "import sagemaker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23c673a9-5b9f-47e0-92cf-bb97486b3e1a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "region = boto3.Session().region_name\n",
+    "\n",
+    "sess = sagemaker.Session(boto3.Session(region_name=region))\n",
+    "\n",
+    "sagemaker_session_bucket = None\n",
+    "if sagemaker_session_bucket is None and sess is not None:\n",
+    "    # set to default bucket if a bucket name is not given\n",
+    "    sagemaker_session_bucket = sess.default_bucket()\n",
+    "\n",
+    "role = sagemaker.get_execution_role()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9786901-b012-41ff-a98a-b16e5f60ec9c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"sagemaker role arn: {role}\")\n",
+    "print(f\"sagemaker bucket: {sess.default_bucket()}\")\n",
+    "print(f\"sagemaker session region: {sess.boto_region_name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "565528c2-9f7d-47aa-bfca-6c35c9112f07",
+   "metadata": {},
+   "source": [
+    "## Data Preparation for Supervised Fine-tuning"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f78bb88-acf9-4cc3-8486-51e03d581b6e",
+   "metadata": {},
+   "source": [
+    "### [Finance-Instruct-500k](https://huggingface.co/datasets/Josephgflowers/Finance-Instruct-500k)\n",
+    "\n",
+    "**Finance-Instruct-500k** is a large-scale dataset with about **518,000 entries** focused on the financial domain. It spans topics such as investments, banking, markets, accounting, and corporate finance, offering a wide variety of instruction\u2013response examples.\n",
+    "\n",
+    "**Data Format & Structure**:\n",
+    "- Distributed in **JSON** format, with simple conversion to Parquet.  \n",
+    "- Contains a single `train` split with ~518k records.  \n",
+    "- Each record includes:  \n",
+    "  - `system` \u2013 context or metadata for the task  \n",
+    "  - `user` \u2013 the financial prompt or query  \n",
+    "  - `assistant` \u2013 the corresponding response  \n",
+    "\n",
+    "**License**: Released under the **Apache-2.0** license.  \n",
+    "\n",
+    "**Applications**:\n",
+    "\n",
+    "The dataset can support finance-focused tasks such as:  \n",
+    "- Financial question answering  \n",
+    "- Market and investment analysis  \n",
+    "- Topic and sentiment classification  \n",
+    "- Financial entity extraction and document understanding  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "745fda33-d065-45c3-b69a-d17a041c3b07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import json\n",
+    "import pprint\n",
+    "from tqdm import tqdm\n",
+    "from datasets import load_dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18e4a8e2-24dc-4e1f-be35-1aed9d6212dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_parent_path = os.path.join(os.getcwd(), \"tmp_cache_local_dataset\")\n",
+    "os.makedirs(dataset_parent_path, exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b18688b5-fc28-4c6c-a1ea-1250dc71acc4",
+   "metadata": {},
+   "source": [
+    "**Preparing Your Dataset in `messages` format**\n",
+    "\n",
+    "This section walks you through creating a conversation-style dataset\u2014the required `messages` format\u2014for directly training LLMs using SageMaker AI.\n",
+    "\n",
+    "**What Is the `messages` Format?**\n",
+    "\n",
+    "The `messages` format structures instances as chat-like exchanges, wrapping each conversation turn into a role-labeled JSON array. It\u2019s widely used by frameworks like TRL.\n",
+    "\n",
+    "Example entry:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "  \"messages\": [\n",
+    "    { \"role\": \"system\", \"content\": \"You are a helpful assistant.\" },\n",
+    "    { \"role\": \"user\", \"content\": \"How do I bake sourdough?\" },\n",
+    "    { \"role\": \"assistant\", \"content\": \"First, you need to create a starter by...\" }\n",
+    "  ]\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "992e9ac9-2b9f-49de-a932-91b459283840",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_name = \"Josephgflowers/Finance-Instruct-500k\"\n",
+    "dataset = load_dataset(dataset_name, split=\"train[:1000]\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9bdbf5d1-9e12-4ee3-985a-713d84c98560",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "pprint.pp(dataset[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "259415f8-cb2a-47c5-bc91-293f4ac704ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"total number of fine-tunable samples: {len(dataset)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85fa8b14-3316-49a4-b67e-aca9d9be6498",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def convert_to_messages(row):\n",
+    "    system_content = \"You are a financial reasoning assistant. Read the user's query, restate the key data, and solve step by step. Show calculations clearly, explain any rounding or adjustments, and present the final answer in a concise and professional manner.\"\n",
+    "    user_content = row[\"user\"]\n",
+    "    assistant_content = row[\"assistant\"]\n",
+    "\n",
+    "    return {\n",
+    "        \"messages\": [\n",
+    "            {\"role\": \"system\", \"content\": system_content},\n",
+    "            {\"role\": \"user\", \"content\": user_content},\n",
+    "            {\"role\": \"assistant\", \"content\": assistant_content},\n",
+    "        ]\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "dataset = dataset.map(convert_to_messages, remove_columns=dataset.column_names)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "434df993-5310-45c4-bb81-0e2fe5181e1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_filename = os.path.join(dataset_parent_path, f\"{dataset_name.replace('/', '--').replace('.', '-')}.jsonl\")\n",
+    "dataset.to_json(dataset_filename, lines=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72c3276e-1cee-40f4-9477-c596863f809e",
+   "metadata": {},
+   "source": [
+    "#### Upload file to S3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ee8f5ea-1d2e-4271-80c0-f984c0e275f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.s3 import S3Uploader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9094fda7-f723-49bc-a2a3-d5ab88ae849d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_s3_uri = f\"s3://{sess.default_bucket()}/dataset\"\n",
+    "\n",
+    "uploaded_s3_uri = S3Uploader.upload(\n",
+    "    local_path=dataset_filename,\n",
+    "    desired_s3_uri=data_s3_uri\n",
+    ")\n",
+    "print(f\"Uploaded {dataset_filename} to > {uploaded_s3_uri}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d28ff7ed-ae76-45ed-9fae-489394738e7e",
+   "metadata": {},
+   "source": [
+    "## Fine-Tune LLMs using SageMaker AI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d7287b14-f829-4256-8839-2b573bc32ee6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "from sagemaker.modules.configs import (\n",
+    "    CheckpointConfig,\n",
+    "    Compute,\n",
+    "    OutputDataConfig,\n",
+    "    SourceCode,\n",
+    "    StoppingCondition,\n",
+    ")\n",
+    "from sagemaker.modules.configs import InputData\n",
+    "from sagemaker.modules.train import ModelTrainer\n",
+    "from getpass import getpass\n",
+    "import yaml\n",
+    "from jinja2 import Template"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8622086a-d844-4475-8433-59ee899a83cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MODEL_ID = \"Qwen/Qwen3.5-4B-Base\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e623397c-7206-4276-9328-b32dd0c1c34f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hf_token = getpass()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f056b30-bb07-4217-8373-2f7a09e4e412",
+   "metadata": {},
+   "source": [
+    "### Training using `PyTorch` Estimator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "227b5c53-404d-4ae2-8d66-b1066a61522a",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "**Observability**: SageMaker AI has [SageMaker MLflow](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) which enables you to accelerate generative AI by making it easier to track experiments and monitor performance of models and AI applications using a single tool.\n",
+    "\n",
+    "You can choose to include MLflow as a part of your training workflow to track your model fine-tuning metrics in realtime by simply specifying a **mlflow** tracking arn.\n",
+    "\n",
+    "Optionally you can also report to : **tensorboard**, **wandb**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f168326f-6e19-45c7-b052-f1587fe71edf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MLFLOW_TRACKING_SERVER_ARN = \"arn:aws:sagemaker:us-east-1:XXXXXYYYYYZZ:mlflow-tracking-server/<name>\" # or None\n",
+    "\n",
+    "if MLFLOW_TRACKING_SERVER_ARN:\n",
+    "    reports_to = \"mlflow\"\n",
+    "else:\n",
+    "    reports_to = \"tensorboard\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e6925c3-46d3-4435-8198-a21ab67da65e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "job_name = MODEL_ID.replace('/', '--').replace('.', '-')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c36d5488-c0d0-4336-b2c8-df3632d2c3a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if MLFLOW_TRACKING_SERVER_ARN:\n",
+    "    training_env = {\n",
+    "        # mlflow tracking metrics\n",
+    "        \"MLFLOW_EXPERIMENT_NAME\": f\"{job_name}-exp\",\n",
+    "        \"MLFLOW_TAGS\": json.dumps(\n",
+    "            {\n",
+    "                \"source.job\": \"sm-training-jobs\", \n",
+    "                \"source.type\": \"sft\", \n",
+    "                \"source.framework\": \"pytorch\"\n",
+    "            }\n",
+    "        ),\n",
+    "        \"MLFLOW_TRACKING_URI\": MLFLOW_TRACKING_SERVER_ARN,\n",
+    "        \"MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING\": \"true\",\n",
+    "        # non tracking metrics - enabled\n",
+    "        \"HF_TOKEN\": hf_token,\n",
+    "        \"FI_EFA_USE_DEVICE_RDMA\": \"1\",\n",
+    "        \"NCCL_DEBUG\": \"INFO\",\n",
+    "        \"NCCL_SOCKET_IFNAME\": \"eth0\",\n",
+    "        \"FI_PROVIDER\": \"efa\",\n",
+    "        \"NCCL_PROTO\": \"simple\",\n",
+    "        \"NCCL_NET_GDR_LEVEL\": \"5\"\n",
+    "    }\n",
+    "else:\n",
+    "    training_env = {\n",
+    "        # non tracking metrics\n",
+    "        \"HF_TOKEN\": hf_token,\n",
+    "        \"FI_EFA_USE_DEVICE_RDMA\": \"1\",\n",
+    "        \"NCCL_DEBUG\": \"INFO\",\n",
+    "        \"NCCL_SOCKET_IFNAME\": \"eth0\",\n",
+    "        \"FI_PROVIDER\": \"efa\",\n",
+    "        \"NCCL_PROTO\": \"simple\",\n",
+    "        \"NCCL_NET_GDR_LEVEL\": \"5\"\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19e6ff10-4311-4bbb-bd60-dd8bcefa039d",
+   "metadata": {},
+   "source": [
+    "#### Training strategy - Choose between: `PeFT`/`Spectrum`/`Full-Finetuning`\n",
+    "\n",
+    "Here we create a measured mapping of strategy to instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# === Backup sagemaker_code/requirements.txt before %%writefile clobbers it ===\n",
+    "# Always overwrite the .bak so re-running the notebook (or running it after a\n",
+    "# different recipe notebook in the same session) captures the *current* state\n",
+    "# as the restore target. The final cell of this notebook restores from .bak.\n",
+    "import shutil, pathlib\n",
+    "_REQ = pathlib.Path(\"sagemaker_code/requirements.txt\")\n",
+    "_BAK = _REQ.with_suffix(\".txt.bak\")\n",
+    "if _REQ.exists():\n",
+    "    shutil.copy2(_REQ, _BAK)\n",
+    "    print(f\"Backed up {_REQ} -> {_BAK}\")\n",
+    "else:\n",
+    "    print(f\"No {_REQ} to back up; skipping.\")\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "478973cd-bbcd-4d47-9734-79fa1b0e8755",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile sagemaker_code/requirements.txt\n",
+    "# === Qwen 3.5 notebook overrides ===\n",
+    "# Bumps for Qwen 3.5 architecture support. Sibling notebooks override this file\n",
+    "# in their cell 28 too, so re-running them after this notebook is harmless.\n",
+    "#\n",
+    "# Why each bump:\n",
+    "#   transformers 5.2.0 \u2014 qwen3_5 architecture not in 4.x\n",
+    "#   peft 0.18.1        \u2014 0.17 imports HybridCache (removed in transformers 5.x)\n",
+    "#   bitsandbytes 0.49.2 \u2014 first version with a CUDA 13.0 binary\n",
+    "#   liger-kernel 0.7.0 \u2014 same HybridCache compatibility as peft\n",
+    "#\n",
+    "transformers==5.2.0\n",
+    "peft==0.18.1\n",
+    "accelerate==1.11.0\n",
+    "bitsandbytes==0.49.2\n",
+    "datasets==4.0.0\n",
+    "deepspeed==0.17.5\n",
+    "hf-transfer==0.1.8\n",
+    "hf_xet\n",
+    "liger-kernel==0.7.0\n",
+    "lm-eval[api]==0.4.9\n",
+    "kernels>=0.9.0\n",
+    "mlflow\n",
+    "Pillow\n",
+    "soundfile\n",
+    "safetensors>=0.6.2\n",
+    "sagemaker==2.251.1\n",
+    "sagemaker-mlflow==0.1.0\n",
+    "sentencepiece==0.2.0\n",
+    "tokenizers>=0.21.4\n",
+    "triton\n",
+    "trl==0.21.0\n",
+    "tensorboard\n",
+    "psutil\n",
+    "py7zr\n",
+    "git+https://github.com/triton-lang/triton.git@main#subdirectory=python/triton_kernels\n",
+    "poetry\n",
+    "yq\n",
+    "psutil\n",
+    "nvidia-ml-py\n",
+    "pyrsmi\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f51158a9-b291-4af8-bcda-362a1dfa7db3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === Choose strategy: QLoRA (4-bit) or Full fine-tuning ===\n",
+    "STRATEGY = \"peft-qlora\"  # one of: \"peft-qlora\", \"full\"\n",
+    "\n",
+    "if STRATEGY == \"peft-qlora\":\n",
+    "    args = [\n",
+    "        \"--config\",\n",
+    "        f\"hf_recipes/Qwen/{MODEL_ID.split('/')[-1]}--vanilla-peft-qlora.yaml\",\n",
+    "    ]\n",
+    "    training_instance_type = \"ml.g5.2xlarge\"\n",
+    "elif STRATEGY == \"full\":\n",
+    "    args = [\n",
+    "        \"--config\",\n",
+    "        f\"hf_recipes/Qwen/{MODEL_ID.split('/')[-1]}--vanilla-full.yaml\",\n",
+    "    ]\n",
+    "    training_instance_type = \"ml.g7e.2xlarge\"\n",
+    "else:\n",
+    "    raise ValueError(f\"unknown STRATEGY: {STRATEGY}\")\n",
+    "\n",
+    "training_instance_count = 1\n",
+    "print(f\"Strategy: {STRATEGY} | Instance: {training_instance_type}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5eefe7b2-f29c-4d17-969b-660c7cf7386f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pytorch_image_uri = sagemaker.image_uris.retrieve(\n",
+    "    framework=\"pytorch\",\n",
+    "    region=sess.boto_session.region_name,\n",
+    "    version=\"2.7.1\",\n",
+    "    instance_type=training_instance_type,\n",
+    "    image_scope=\"training\",\n",
+    ")\n",
+    "print(f\"Using image: {pytorch_image_uri}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9308684f-4d04-4146-b6a5-3527d07039b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source_code = SourceCode(\n",
+    "    source_dir=\"./sagemaker_code\",\n",
+    "    command=f\"bash sm_accelerate_train.sh {' '.join(args)}\",\n",
+    ")\n",
+    "\n",
+    "compute_configs = Compute(\n",
+    "    instance_type=training_instance_type,\n",
+    "    instance_count=training_instance_count,\n",
+    "    keep_alive_period_in_seconds=1800,\n",
+    "    volume_size_in_gb=300\n",
+    ")\n",
+    "\n",
+    "base_job_name = f\"{job_name}-finetune\"\n",
+    "output_path = f\"s3://{sess.default_bucket()}/{base_job_name}\"\n",
+    "\n",
+    "model_trainer = ModelTrainer(\n",
+    "    training_image=pytorch_image_uri,\n",
+    "    source_code=source_code,\n",
+    "    base_job_name=base_job_name,\n",
+    "    compute=compute_configs,\n",
+    "    stopping_condition=StoppingCondition(max_runtime_in_seconds=18000),\n",
+    "    output_data_config=OutputDataConfig(\n",
+    "        s3_output_path=output_path,\n",
+    "    ),\n",
+    "    checkpoint_config=CheckpointConfig(\n",
+    "        s3_uri=os.path.join(\n",
+    "            output_path,\n",
+    "            dataset_name.replace('/', '--').replace('.', '-'), \n",
+    "            job_name,\n",
+    "            \"checkpoints\"\n",
+    "        ), \n",
+    "        local_path=\"/opt/ml/checkpoints\"\n",
+    "    ),\n",
+    "    role=role,\n",
+    "    environment=training_env\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f2699f9-03aa-467e-98d0-8259bcab1308",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_trainer.train(\n",
+    "    input_data_config=[\n",
+    "        InputData(\n",
+    "            channel_name=\"training\",\n",
+    "            data_source=uploaded_s3_uri,  \n",
+    "        )\n",
+    "    ], \n",
+    "    wait=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Cleanup \u2014 restore upstream `requirements.txt`\n",
+    "\n",
+    "Run this cell after the training job is queued / completed to leave `sagemaker_code/` exactly as it was before this notebook ran.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# === Restore upstream requirements.txt from .bak ===\n",
+    "import pathlib, shutil\n",
+    "_BAK = pathlib.Path(\"sagemaker_code/requirements.txt.bak\")\n",
+    "if _BAK.exists():\n",
+    "    target = _BAK.with_suffix(\"\")\n",
+    "    shutil.copy2(_BAK, target)\n",
+    "    _BAK.unlink()\n",
+    "    print(f\"Restored {target} from .bak\")\n",
+    "else:\n",
+    "    print(\"No backup found; nothing to restore.\")\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Where to find the trained adapter / model\n",
+    "\n",
+    "After training completes, artifacts land at `s3://<bucket>/<job-name>/output/model.tar.gz`.\n",
+    "\n",
+    "| Strategy | Tarball contents |\n",
+    "|---|---|\n",
+    "| QLoRA | `Qwen/<model>/peft_adapter/` containing standard PEFT files (`adapter_config.json`, `adapter_model.safetensors`, tokenizer, chat template) \u2014 vLLM `--enable-lora`, DJL Serving / LMI, and Bedrock all consume it directly |\n",
+    "| Full | Sharded `safetensors` of the merged checkpoint, ready for direct inference deployment |\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/0_model_customization_recipes/supervised_finetuning/finetune--Qwen--Qwen3.5-4B.ipynb
+++ b/0_model_customization_recipes/supervised_finetuning/finetune--Qwen--Qwen3.5-4B.ipynb
@@ -1,0 +1,672 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e60b91a9-7d9c-4c45-be0f-5a224581f644",
+   "metadata": {},
+   "source": [
+    "# \ud83d\ude80 Customize and Deploy `Qwen/Qwen3.5-4B` on Amazon SageMaker AI\n",
+    "---\n",
+    "This notebook fine-tunes **Qwen3.5-4B (Instruct)** (~4 billion (post-trained / Instruct variant)) on Amazon SageMaker Training Jobs using the shared `sagemaker_code/sft.py` driver. Both QLoRA (4-bit) and full fine-tuning are supported via the strategy chooser cell.\n",
+    "\n",
+    "\ud83d\udd17 Model card: [Qwen/Qwen3.5-4B on Hugging Face](https://huggingface.co/Qwen/Qwen3.5-4B)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Validated configurations**:\n",
+    "\n",
+    "| Strategy | Default instance | GPU(s) | Wall clock (typical) |\n",
+    "|---|---|---|---|\n",
+    "| QLoRA (4-bit) | `ml.g5.2xlarge` | 1\u00d7 A10G 24 GB | ~20-30 min |\n",
+    "| Full fine-tuning | `ml.g7e.2xlarge` | 1\u00d7 RTX PRO 6000 Blackwell 96 GB | ~30-50 min |\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Why this notebook overrides `sagemaker_code/requirements.txt`**\n",
+    "\n",
+    "Qwen 3.5 introduces a new model architecture (`qwen3_5`) that requires `transformers >= 5.2.0`. The shared `requirements.txt` pins `transformers==4.57.0`, so the cell below overrides the file via `%%writefile` (with a backed-up `.bak`, restored by the final cell):\n",
+    "\n",
+    "| Package | Shared default | Required | Why |\n",
+    "|---|---|---|---|\n",
+    "| `transformers` | 4.57.0 | 5.2.0 | `qwen3_5` architecture not in 4.x |\n",
+    "| `peft` | 0.17.0 | 0.18.1 | `HybridCache` removed in transformers 5.x |\n",
+    "| `bitsandbytes` | 0.46.1 | 0.49.2 | First version with a CUDA 13.0 binary |\n",
+    "| `liger-kernel` | 0.6.1 | 0.7.0 | Same `HybridCache` compatibility issue |\n",
+    "\n",
+    "`trl == 0.21.0` and the rest of the toolchain are unchanged \u2014 Qwen 3.5 works with the existing `sft.py` and `merge_adapter_weights.py` without source-code patches.\n",
+    "\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ce40054-610a-4acc-a546-943893f293c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -Uq \"datasets==4.3.0\" \\\n",
+    "    \"sagemaker==2.253.1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b791e72e-82b5-4f8e-a7fe-700e8afdeba5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "import sagemaker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23c673a9-5b9f-47e0-92cf-bb97486b3e1a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "region = boto3.Session().region_name\n",
+    "\n",
+    "sess = sagemaker.Session(boto3.Session(region_name=region))\n",
+    "\n",
+    "sagemaker_session_bucket = None\n",
+    "if sagemaker_session_bucket is None and sess is not None:\n",
+    "    # set to default bucket if a bucket name is not given\n",
+    "    sagemaker_session_bucket = sess.default_bucket()\n",
+    "\n",
+    "role = sagemaker.get_execution_role()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9786901-b012-41ff-a98a-b16e5f60ec9c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"sagemaker role arn: {role}\")\n",
+    "print(f\"sagemaker bucket: {sess.default_bucket()}\")\n",
+    "print(f\"sagemaker session region: {sess.boto_region_name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "565528c2-9f7d-47aa-bfca-6c35c9112f07",
+   "metadata": {},
+   "source": [
+    "## Data Preparation for Supervised Fine-tuning"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f78bb88-acf9-4cc3-8486-51e03d581b6e",
+   "metadata": {},
+   "source": [
+    "### [Finance-Instruct-500k](https://huggingface.co/datasets/Josephgflowers/Finance-Instruct-500k)\n",
+    "\n",
+    "**Finance-Instruct-500k** is a large-scale dataset with about **518,000 entries** focused on the financial domain. It spans topics such as investments, banking, markets, accounting, and corporate finance, offering a wide variety of instruction\u2013response examples.\n",
+    "\n",
+    "**Data Format & Structure**:\n",
+    "- Distributed in **JSON** format, with simple conversion to Parquet.  \n",
+    "- Contains a single `train` split with ~518k records.  \n",
+    "- Each record includes:  \n",
+    "  - `system` \u2013 context or metadata for the task  \n",
+    "  - `user` \u2013 the financial prompt or query  \n",
+    "  - `assistant` \u2013 the corresponding response  \n",
+    "\n",
+    "**License**: Released under the **Apache-2.0** license.  \n",
+    "\n",
+    "**Applications**:\n",
+    "\n",
+    "The dataset can support finance-focused tasks such as:  \n",
+    "- Financial question answering  \n",
+    "- Market and investment analysis  \n",
+    "- Topic and sentiment classification  \n",
+    "- Financial entity extraction and document understanding  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "745fda33-d065-45c3-b69a-d17a041c3b07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import json\n",
+    "import pprint\n",
+    "from tqdm import tqdm\n",
+    "from datasets import load_dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18e4a8e2-24dc-4e1f-be35-1aed9d6212dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_parent_path = os.path.join(os.getcwd(), \"tmp_cache_local_dataset\")\n",
+    "os.makedirs(dataset_parent_path, exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b18688b5-fc28-4c6c-a1ea-1250dc71acc4",
+   "metadata": {},
+   "source": [
+    "**Preparing Your Dataset in `messages` format**\n",
+    "\n",
+    "This section walks you through creating a conversation-style dataset\u2014the required `messages` format\u2014for directly training LLMs using SageMaker AI.\n",
+    "\n",
+    "**What Is the `messages` Format?**\n",
+    "\n",
+    "The `messages` format structures instances as chat-like exchanges, wrapping each conversation turn into a role-labeled JSON array. It\u2019s widely used by frameworks like TRL.\n",
+    "\n",
+    "Example entry:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "  \"messages\": [\n",
+    "    { \"role\": \"system\", \"content\": \"You are a helpful assistant.\" },\n",
+    "    { \"role\": \"user\", \"content\": \"How do I bake sourdough?\" },\n",
+    "    { \"role\": \"assistant\", \"content\": \"First, you need to create a starter by...\" }\n",
+    "  ]\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "992e9ac9-2b9f-49de-a932-91b459283840",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_name = \"Josephgflowers/Finance-Instruct-500k\"\n",
+    "dataset = load_dataset(dataset_name, split=\"train[:1000]\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9bdbf5d1-9e12-4ee3-985a-713d84c98560",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "pprint.pp(dataset[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "259415f8-cb2a-47c5-bc91-293f4ac704ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"total number of fine-tunable samples: {len(dataset)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85fa8b14-3316-49a4-b67e-aca9d9be6498",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def convert_to_messages(row):\n",
+    "    system_content = \"You are a financial reasoning assistant. Read the user's query, restate the key data, and solve step by step. Show calculations clearly, explain any rounding or adjustments, and present the final answer in a concise and professional manner.\"\n",
+    "    user_content = row[\"user\"]\n",
+    "    assistant_content = row[\"assistant\"]\n",
+    "\n",
+    "    return {\n",
+    "        \"messages\": [\n",
+    "            {\"role\": \"system\", \"content\": system_content},\n",
+    "            {\"role\": \"user\", \"content\": user_content},\n",
+    "            {\"role\": \"assistant\", \"content\": assistant_content},\n",
+    "        ]\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "dataset = dataset.map(convert_to_messages, remove_columns=dataset.column_names)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "434df993-5310-45c4-bb81-0e2fe5181e1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_filename = os.path.join(dataset_parent_path, f\"{dataset_name.replace('/', '--').replace('.', '-')}.jsonl\")\n",
+    "dataset.to_json(dataset_filename, lines=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72c3276e-1cee-40f4-9477-c596863f809e",
+   "metadata": {},
+   "source": [
+    "#### Upload file to S3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ee8f5ea-1d2e-4271-80c0-f984c0e275f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.s3 import S3Uploader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9094fda7-f723-49bc-a2a3-d5ab88ae849d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_s3_uri = f\"s3://{sess.default_bucket()}/dataset\"\n",
+    "\n",
+    "uploaded_s3_uri = S3Uploader.upload(\n",
+    "    local_path=dataset_filename,\n",
+    "    desired_s3_uri=data_s3_uri\n",
+    ")\n",
+    "print(f\"Uploaded {dataset_filename} to > {uploaded_s3_uri}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d28ff7ed-ae76-45ed-9fae-489394738e7e",
+   "metadata": {},
+   "source": [
+    "## Fine-Tune LLMs using SageMaker AI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d7287b14-f829-4256-8839-2b573bc32ee6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "from sagemaker.modules.configs import (\n",
+    "    CheckpointConfig,\n",
+    "    Compute,\n",
+    "    OutputDataConfig,\n",
+    "    SourceCode,\n",
+    "    StoppingCondition,\n",
+    ")\n",
+    "from sagemaker.modules.configs import InputData\n",
+    "from sagemaker.modules.train import ModelTrainer\n",
+    "from getpass import getpass\n",
+    "import yaml\n",
+    "from jinja2 import Template"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8622086a-d844-4475-8433-59ee899a83cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MODEL_ID = \"Qwen/Qwen3.5-4B\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e623397c-7206-4276-9328-b32dd0c1c34f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hf_token = getpass()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f056b30-bb07-4217-8373-2f7a09e4e412",
+   "metadata": {},
+   "source": [
+    "### Training using `PyTorch` Estimator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "227b5c53-404d-4ae2-8d66-b1066a61522a",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "**Observability**: SageMaker AI has [SageMaker MLflow](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) which enables you to accelerate generative AI by making it easier to track experiments and monitor performance of models and AI applications using a single tool.\n",
+    "\n",
+    "You can choose to include MLflow as a part of your training workflow to track your model fine-tuning metrics in realtime by simply specifying a **mlflow** tracking arn.\n",
+    "\n",
+    "Optionally you can also report to : **tensorboard**, **wandb**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f168326f-6e19-45c7-b052-f1587fe71edf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MLFLOW_TRACKING_SERVER_ARN = \"arn:aws:sagemaker:us-east-1:XXXXXYYYYYZZ:mlflow-tracking-server/<name>\" # or None\n",
+    "\n",
+    "if MLFLOW_TRACKING_SERVER_ARN:\n",
+    "    reports_to = \"mlflow\"\n",
+    "else:\n",
+    "    reports_to = \"tensorboard\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e6925c3-46d3-4435-8198-a21ab67da65e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "job_name = MODEL_ID.replace('/', '--').replace('.', '-')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c36d5488-c0d0-4336-b2c8-df3632d2c3a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if MLFLOW_TRACKING_SERVER_ARN:\n",
+    "    training_env = {\n",
+    "        # mlflow tracking metrics\n",
+    "        \"MLFLOW_EXPERIMENT_NAME\": f\"{job_name}-exp\",\n",
+    "        \"MLFLOW_TAGS\": json.dumps(\n",
+    "            {\n",
+    "                \"source.job\": \"sm-training-jobs\", \n",
+    "                \"source.type\": \"sft\", \n",
+    "                \"source.framework\": \"pytorch\"\n",
+    "            }\n",
+    "        ),\n",
+    "        \"MLFLOW_TRACKING_URI\": MLFLOW_TRACKING_SERVER_ARN,\n",
+    "        \"MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING\": \"true\",\n",
+    "        # non tracking metrics - enabled\n",
+    "        \"HF_TOKEN\": hf_token,\n",
+    "        \"FI_EFA_USE_DEVICE_RDMA\": \"1\",\n",
+    "        \"NCCL_DEBUG\": \"INFO\",\n",
+    "        \"NCCL_SOCKET_IFNAME\": \"eth0\",\n",
+    "        \"FI_PROVIDER\": \"efa\",\n",
+    "        \"NCCL_PROTO\": \"simple\",\n",
+    "        \"NCCL_NET_GDR_LEVEL\": \"5\"\n",
+    "    }\n",
+    "else:\n",
+    "    training_env = {\n",
+    "        # non tracking metrics\n",
+    "        \"HF_TOKEN\": hf_token,\n",
+    "        \"FI_EFA_USE_DEVICE_RDMA\": \"1\",\n",
+    "        \"NCCL_DEBUG\": \"INFO\",\n",
+    "        \"NCCL_SOCKET_IFNAME\": \"eth0\",\n",
+    "        \"FI_PROVIDER\": \"efa\",\n",
+    "        \"NCCL_PROTO\": \"simple\",\n",
+    "        \"NCCL_NET_GDR_LEVEL\": \"5\"\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19e6ff10-4311-4bbb-bd60-dd8bcefa039d",
+   "metadata": {},
+   "source": [
+    "#### Training strategy - Choose between: `PeFT`/`Spectrum`/`Full-Finetuning`\n",
+    "\n",
+    "Here we create a measured mapping of strategy to instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# === Backup sagemaker_code/requirements.txt before %%writefile clobbers it ===\n",
+    "# Always overwrite the .bak so re-running the notebook (or running it after a\n",
+    "# different recipe notebook in the same session) captures the *current* state\n",
+    "# as the restore target. The final cell of this notebook restores from .bak.\n",
+    "import shutil, pathlib\n",
+    "_REQ = pathlib.Path(\"sagemaker_code/requirements.txt\")\n",
+    "_BAK = _REQ.with_suffix(\".txt.bak\")\n",
+    "if _REQ.exists():\n",
+    "    shutil.copy2(_REQ, _BAK)\n",
+    "    print(f\"Backed up {_REQ} -> {_BAK}\")\n",
+    "else:\n",
+    "    print(f\"No {_REQ} to back up; skipping.\")\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "478973cd-bbcd-4d47-9734-79fa1b0e8755",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile sagemaker_code/requirements.txt\n",
+    "# === Qwen 3.5 notebook overrides ===\n",
+    "# Bumps for Qwen 3.5 architecture support. Sibling notebooks override this file\n",
+    "# in their cell 28 too, so re-running them after this notebook is harmless.\n",
+    "#\n",
+    "# Why each bump:\n",
+    "#   transformers 5.2.0 \u2014 qwen3_5 architecture not in 4.x\n",
+    "#   peft 0.18.1        \u2014 0.17 imports HybridCache (removed in transformers 5.x)\n",
+    "#   bitsandbytes 0.49.2 \u2014 first version with a CUDA 13.0 binary\n",
+    "#   liger-kernel 0.7.0 \u2014 same HybridCache compatibility as peft\n",
+    "#\n",
+    "transformers==5.2.0\n",
+    "peft==0.18.1\n",
+    "accelerate==1.11.0\n",
+    "bitsandbytes==0.49.2\n",
+    "datasets==4.0.0\n",
+    "deepspeed==0.17.5\n",
+    "hf-transfer==0.1.8\n",
+    "hf_xet\n",
+    "liger-kernel==0.7.0\n",
+    "lm-eval[api]==0.4.9\n",
+    "kernels>=0.9.0\n",
+    "mlflow\n",
+    "Pillow\n",
+    "soundfile\n",
+    "safetensors>=0.6.2\n",
+    "sagemaker==2.251.1\n",
+    "sagemaker-mlflow==0.1.0\n",
+    "sentencepiece==0.2.0\n",
+    "tokenizers>=0.21.4\n",
+    "triton\n",
+    "trl==0.21.0\n",
+    "tensorboard\n",
+    "psutil\n",
+    "py7zr\n",
+    "git+https://github.com/triton-lang/triton.git@main#subdirectory=python/triton_kernels\n",
+    "poetry\n",
+    "yq\n",
+    "psutil\n",
+    "nvidia-ml-py\n",
+    "pyrsmi\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f51158a9-b291-4af8-bcda-362a1dfa7db3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === Choose strategy: QLoRA (4-bit) or Full fine-tuning ===\n",
+    "STRATEGY = \"peft-qlora\"  # one of: \"peft-qlora\", \"full\"\n",
+    "\n",
+    "if STRATEGY == \"peft-qlora\":\n",
+    "    args = [\n",
+    "        \"--config\",\n",
+    "        f\"hf_recipes/Qwen/{MODEL_ID.split('/')[-1]}--vanilla-peft-qlora.yaml\",\n",
+    "    ]\n",
+    "    training_instance_type = \"ml.g5.2xlarge\"\n",
+    "elif STRATEGY == \"full\":\n",
+    "    args = [\n",
+    "        \"--config\",\n",
+    "        f\"hf_recipes/Qwen/{MODEL_ID.split('/')[-1]}--vanilla-full.yaml\",\n",
+    "    ]\n",
+    "    training_instance_type = \"ml.g7e.2xlarge\"\n",
+    "else:\n",
+    "    raise ValueError(f\"unknown STRATEGY: {STRATEGY}\")\n",
+    "\n",
+    "training_instance_count = 1\n",
+    "print(f\"Strategy: {STRATEGY} | Instance: {training_instance_type}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5eefe7b2-f29c-4d17-969b-660c7cf7386f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pytorch_image_uri = sagemaker.image_uris.retrieve(\n",
+    "    framework=\"pytorch\",\n",
+    "    region=sess.boto_session.region_name,\n",
+    "    version=\"2.7.1\",\n",
+    "    instance_type=training_instance_type,\n",
+    "    image_scope=\"training\",\n",
+    ")\n",
+    "print(f\"Using image: {pytorch_image_uri}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9308684f-4d04-4146-b6a5-3527d07039b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source_code = SourceCode(\n",
+    "    source_dir=\"./sagemaker_code\",\n",
+    "    command=f\"bash sm_accelerate_train.sh {' '.join(args)}\",\n",
+    ")\n",
+    "\n",
+    "compute_configs = Compute(\n",
+    "    instance_type=training_instance_type,\n",
+    "    instance_count=training_instance_count,\n",
+    "    keep_alive_period_in_seconds=1800,\n",
+    "    volume_size_in_gb=300\n",
+    ")\n",
+    "\n",
+    "base_job_name = f\"{job_name}-finetune\"\n",
+    "output_path = f\"s3://{sess.default_bucket()}/{base_job_name}\"\n",
+    "\n",
+    "model_trainer = ModelTrainer(\n",
+    "    training_image=pytorch_image_uri,\n",
+    "    source_code=source_code,\n",
+    "    base_job_name=base_job_name,\n",
+    "    compute=compute_configs,\n",
+    "    stopping_condition=StoppingCondition(max_runtime_in_seconds=18000),\n",
+    "    output_data_config=OutputDataConfig(\n",
+    "        s3_output_path=output_path,\n",
+    "    ),\n",
+    "    checkpoint_config=CheckpointConfig(\n",
+    "        s3_uri=os.path.join(\n",
+    "            output_path,\n",
+    "            dataset_name.replace('/', '--').replace('.', '-'), \n",
+    "            job_name,\n",
+    "            \"checkpoints\"\n",
+    "        ), \n",
+    "        local_path=\"/opt/ml/checkpoints\"\n",
+    "    ),\n",
+    "    role=role,\n",
+    "    environment=training_env\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f2699f9-03aa-467e-98d0-8259bcab1308",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_trainer.train(\n",
+    "    input_data_config=[\n",
+    "        InputData(\n",
+    "            channel_name=\"training\",\n",
+    "            data_source=uploaded_s3_uri,  \n",
+    "        )\n",
+    "    ], \n",
+    "    wait=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Cleanup \u2014 restore upstream `requirements.txt`\n",
+    "\n",
+    "Run this cell after the training job is queued / completed to leave `sagemaker_code/` exactly as it was before this notebook ran.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# === Restore upstream requirements.txt from .bak ===\n",
+    "import pathlib, shutil\n",
+    "_BAK = pathlib.Path(\"sagemaker_code/requirements.txt.bak\")\n",
+    "if _BAK.exists():\n",
+    "    target = _BAK.with_suffix(\"\")\n",
+    "    shutil.copy2(_BAK, target)\n",
+    "    _BAK.unlink()\n",
+    "    print(f\"Restored {target} from .bak\")\n",
+    "else:\n",
+    "    print(\"No backup found; nothing to restore.\")\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Where to find the trained adapter / model\n",
+    "\n",
+    "After training completes, artifacts land at `s3://<bucket>/<job-name>/output/model.tar.gz`.\n",
+    "\n",
+    "| Strategy | Tarball contents |\n",
+    "|---|---|\n",
+    "| QLoRA | `Qwen/<model>/peft_adapter/` containing standard PEFT files (`adapter_config.json`, `adapter_model.safetensors`, tokenizer, chat template) \u2014 vLLM `--enable-lora`, DJL Serving / LMI, and Bedrock all consume it directly |\n",
+    "| Full | Sharded `safetensors` of the merged checkpoint, ready for direct inference deployment |\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/0_model_customization_recipes/supervised_finetuning/finetune--Qwen--Qwen3.5-9B-Base.ipynb
+++ b/0_model_customization_recipes/supervised_finetuning/finetune--Qwen--Qwen3.5-9B-Base.ipynb
@@ -1,0 +1,672 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e60b91a9-7d9c-4c45-be0f-5a224581f644",
+   "metadata": {},
+   "source": [
+    "# \ud83d\ude80 Customize and Deploy `Qwen/Qwen3.5-9B-Base` on Amazon SageMaker AI\n",
+    "---\n",
+    "This notebook fine-tunes **Qwen3.5-9B-Base** (~9 billion) on Amazon SageMaker Training Jobs using the shared `sagemaker_code/sft.py` driver. Both QLoRA (4-bit) and full fine-tuning are supported via the strategy chooser cell.\n",
+    "\n",
+    "\ud83d\udd17 Model card: [Qwen/Qwen3.5-9B-Base on Hugging Face](https://huggingface.co/Qwen/Qwen3.5-9B-Base)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Validated configurations**:\n",
+    "\n",
+    "| Strategy | Default instance | GPU(s) | Wall clock (typical) |\n",
+    "|---|---|---|---|\n",
+    "| QLoRA (4-bit) | `ml.g5.2xlarge` | 1\u00d7 A10G 24 GB | ~20-30 min |\n",
+    "| Full fine-tuning | `ml.g7e.12xlarge` | 4\u00d7 RTX PRO 6000 Blackwell 384 GB total | ~30-50 min |\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Why this notebook overrides `sagemaker_code/requirements.txt`**\n",
+    "\n",
+    "Qwen 3.5 introduces a new model architecture (`qwen3_5`) that requires `transformers >= 5.2.0`. The shared `requirements.txt` pins `transformers==4.57.0`, so the cell below overrides the file via `%%writefile` (with a backed-up `.bak`, restored by the final cell):\n",
+    "\n",
+    "| Package | Shared default | Required | Why |\n",
+    "|---|---|---|---|\n",
+    "| `transformers` | 4.57.0 | 5.2.0 | `qwen3_5` architecture not in 4.x |\n",
+    "| `peft` | 0.17.0 | 0.18.1 | `HybridCache` removed in transformers 5.x |\n",
+    "| `bitsandbytes` | 0.46.1 | 0.49.2 | First version with a CUDA 13.0 binary |\n",
+    "| `liger-kernel` | 0.6.1 | 0.7.0 | Same `HybridCache` compatibility issue |\n",
+    "\n",
+    "`trl == 0.21.0` and the rest of the toolchain are unchanged \u2014 Qwen 3.5 works with the existing `sft.py` and `merge_adapter_weights.py` without source-code patches.\n",
+    "\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ce40054-610a-4acc-a546-943893f293c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -Uq \"datasets==4.3.0\" \\\n",
+    "    \"sagemaker==2.253.1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b791e72e-82b5-4f8e-a7fe-700e8afdeba5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "import sagemaker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23c673a9-5b9f-47e0-92cf-bb97486b3e1a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "region = boto3.Session().region_name\n",
+    "\n",
+    "sess = sagemaker.Session(boto3.Session(region_name=region))\n",
+    "\n",
+    "sagemaker_session_bucket = None\n",
+    "if sagemaker_session_bucket is None and sess is not None:\n",
+    "    # set to default bucket if a bucket name is not given\n",
+    "    sagemaker_session_bucket = sess.default_bucket()\n",
+    "\n",
+    "role = sagemaker.get_execution_role()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9786901-b012-41ff-a98a-b16e5f60ec9c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"sagemaker role arn: {role}\")\n",
+    "print(f\"sagemaker bucket: {sess.default_bucket()}\")\n",
+    "print(f\"sagemaker session region: {sess.boto_region_name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "565528c2-9f7d-47aa-bfca-6c35c9112f07",
+   "metadata": {},
+   "source": [
+    "## Data Preparation for Supervised Fine-tuning"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f78bb88-acf9-4cc3-8486-51e03d581b6e",
+   "metadata": {},
+   "source": [
+    "### [Finance-Instruct-500k](https://huggingface.co/datasets/Josephgflowers/Finance-Instruct-500k)\n",
+    "\n",
+    "**Finance-Instruct-500k** is a large-scale dataset with about **518,000 entries** focused on the financial domain. It spans topics such as investments, banking, markets, accounting, and corporate finance, offering a wide variety of instruction\u2013response examples.\n",
+    "\n",
+    "**Data Format & Structure**:\n",
+    "- Distributed in **JSON** format, with simple conversion to Parquet.  \n",
+    "- Contains a single `train` split with ~518k records.  \n",
+    "- Each record includes:  \n",
+    "  - `system` \u2013 context or metadata for the task  \n",
+    "  - `user` \u2013 the financial prompt or query  \n",
+    "  - `assistant` \u2013 the corresponding response  \n",
+    "\n",
+    "**License**: Released under the **Apache-2.0** license.  \n",
+    "\n",
+    "**Applications**:\n",
+    "\n",
+    "The dataset can support finance-focused tasks such as:  \n",
+    "- Financial question answering  \n",
+    "- Market and investment analysis  \n",
+    "- Topic and sentiment classification  \n",
+    "- Financial entity extraction and document understanding  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "745fda33-d065-45c3-b69a-d17a041c3b07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import json\n",
+    "import pprint\n",
+    "from tqdm import tqdm\n",
+    "from datasets import load_dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18e4a8e2-24dc-4e1f-be35-1aed9d6212dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_parent_path = os.path.join(os.getcwd(), \"tmp_cache_local_dataset\")\n",
+    "os.makedirs(dataset_parent_path, exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b18688b5-fc28-4c6c-a1ea-1250dc71acc4",
+   "metadata": {},
+   "source": [
+    "**Preparing Your Dataset in `messages` format**\n",
+    "\n",
+    "This section walks you through creating a conversation-style dataset\u2014the required `messages` format\u2014for directly training LLMs using SageMaker AI.\n",
+    "\n",
+    "**What Is the `messages` Format?**\n",
+    "\n",
+    "The `messages` format structures instances as chat-like exchanges, wrapping each conversation turn into a role-labeled JSON array. It\u2019s widely used by frameworks like TRL.\n",
+    "\n",
+    "Example entry:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "  \"messages\": [\n",
+    "    { \"role\": \"system\", \"content\": \"You are a helpful assistant.\" },\n",
+    "    { \"role\": \"user\", \"content\": \"How do I bake sourdough?\" },\n",
+    "    { \"role\": \"assistant\", \"content\": \"First, you need to create a starter by...\" }\n",
+    "  ]\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "992e9ac9-2b9f-49de-a932-91b459283840",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_name = \"Josephgflowers/Finance-Instruct-500k\"\n",
+    "dataset = load_dataset(dataset_name, split=\"train[:1000]\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9bdbf5d1-9e12-4ee3-985a-713d84c98560",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "pprint.pp(dataset[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "259415f8-cb2a-47c5-bc91-293f4ac704ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"total number of fine-tunable samples: {len(dataset)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85fa8b14-3316-49a4-b67e-aca9d9be6498",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def convert_to_messages(row):\n",
+    "    system_content = \"You are a financial reasoning assistant. Read the user's query, restate the key data, and solve step by step. Show calculations clearly, explain any rounding or adjustments, and present the final answer in a concise and professional manner.\"\n",
+    "    user_content = row[\"user\"]\n",
+    "    assistant_content = row[\"assistant\"]\n",
+    "\n",
+    "    return {\n",
+    "        \"messages\": [\n",
+    "            {\"role\": \"system\", \"content\": system_content},\n",
+    "            {\"role\": \"user\", \"content\": user_content},\n",
+    "            {\"role\": \"assistant\", \"content\": assistant_content},\n",
+    "        ]\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "dataset = dataset.map(convert_to_messages, remove_columns=dataset.column_names)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "434df993-5310-45c4-bb81-0e2fe5181e1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_filename = os.path.join(dataset_parent_path, f\"{dataset_name.replace('/', '--').replace('.', '-')}.jsonl\")\n",
+    "dataset.to_json(dataset_filename, lines=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72c3276e-1cee-40f4-9477-c596863f809e",
+   "metadata": {},
+   "source": [
+    "#### Upload file to S3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ee8f5ea-1d2e-4271-80c0-f984c0e275f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.s3 import S3Uploader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9094fda7-f723-49bc-a2a3-d5ab88ae849d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_s3_uri = f\"s3://{sess.default_bucket()}/dataset\"\n",
+    "\n",
+    "uploaded_s3_uri = S3Uploader.upload(\n",
+    "    local_path=dataset_filename,\n",
+    "    desired_s3_uri=data_s3_uri\n",
+    ")\n",
+    "print(f\"Uploaded {dataset_filename} to > {uploaded_s3_uri}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d28ff7ed-ae76-45ed-9fae-489394738e7e",
+   "metadata": {},
+   "source": [
+    "## Fine-Tune LLMs using SageMaker AI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d7287b14-f829-4256-8839-2b573bc32ee6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "from sagemaker.modules.configs import (\n",
+    "    CheckpointConfig,\n",
+    "    Compute,\n",
+    "    OutputDataConfig,\n",
+    "    SourceCode,\n",
+    "    StoppingCondition,\n",
+    ")\n",
+    "from sagemaker.modules.configs import InputData\n",
+    "from sagemaker.modules.train import ModelTrainer\n",
+    "from getpass import getpass\n",
+    "import yaml\n",
+    "from jinja2 import Template"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8622086a-d844-4475-8433-59ee899a83cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MODEL_ID = \"Qwen/Qwen3.5-9B-Base\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e623397c-7206-4276-9328-b32dd0c1c34f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hf_token = getpass()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f056b30-bb07-4217-8373-2f7a09e4e412",
+   "metadata": {},
+   "source": [
+    "### Training using `PyTorch` Estimator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "227b5c53-404d-4ae2-8d66-b1066a61522a",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "**Observability**: SageMaker AI has [SageMaker MLflow](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) which enables you to accelerate generative AI by making it easier to track experiments and monitor performance of models and AI applications using a single tool.\n",
+    "\n",
+    "You can choose to include MLflow as a part of your training workflow to track your model fine-tuning metrics in realtime by simply specifying a **mlflow** tracking arn.\n",
+    "\n",
+    "Optionally you can also report to : **tensorboard**, **wandb**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f168326f-6e19-45c7-b052-f1587fe71edf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MLFLOW_TRACKING_SERVER_ARN = \"arn:aws:sagemaker:us-east-1:XXXXXYYYYYZZ:mlflow-tracking-server/<name>\" # or None\n",
+    "\n",
+    "if MLFLOW_TRACKING_SERVER_ARN:\n",
+    "    reports_to = \"mlflow\"\n",
+    "else:\n",
+    "    reports_to = \"tensorboard\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e6925c3-46d3-4435-8198-a21ab67da65e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "job_name = MODEL_ID.replace('/', '--').replace('.', '-')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c36d5488-c0d0-4336-b2c8-df3632d2c3a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if MLFLOW_TRACKING_SERVER_ARN:\n",
+    "    training_env = {\n",
+    "        # mlflow tracking metrics\n",
+    "        \"MLFLOW_EXPERIMENT_NAME\": f\"{job_name}-exp\",\n",
+    "        \"MLFLOW_TAGS\": json.dumps(\n",
+    "            {\n",
+    "                \"source.job\": \"sm-training-jobs\", \n",
+    "                \"source.type\": \"sft\", \n",
+    "                \"source.framework\": \"pytorch\"\n",
+    "            }\n",
+    "        ),\n",
+    "        \"MLFLOW_TRACKING_URI\": MLFLOW_TRACKING_SERVER_ARN,\n",
+    "        \"MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING\": \"true\",\n",
+    "        # non tracking metrics - enabled\n",
+    "        \"HF_TOKEN\": hf_token,\n",
+    "        \"FI_EFA_USE_DEVICE_RDMA\": \"1\",\n",
+    "        \"NCCL_DEBUG\": \"INFO\",\n",
+    "        \"NCCL_SOCKET_IFNAME\": \"eth0\",\n",
+    "        \"FI_PROVIDER\": \"efa\",\n",
+    "        \"NCCL_PROTO\": \"simple\",\n",
+    "        \"NCCL_NET_GDR_LEVEL\": \"5\"\n",
+    "    }\n",
+    "else:\n",
+    "    training_env = {\n",
+    "        # non tracking metrics\n",
+    "        \"HF_TOKEN\": hf_token,\n",
+    "        \"FI_EFA_USE_DEVICE_RDMA\": \"1\",\n",
+    "        \"NCCL_DEBUG\": \"INFO\",\n",
+    "        \"NCCL_SOCKET_IFNAME\": \"eth0\",\n",
+    "        \"FI_PROVIDER\": \"efa\",\n",
+    "        \"NCCL_PROTO\": \"simple\",\n",
+    "        \"NCCL_NET_GDR_LEVEL\": \"5\"\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19e6ff10-4311-4bbb-bd60-dd8bcefa039d",
+   "metadata": {},
+   "source": [
+    "#### Training strategy - Choose between: `PeFT`/`Spectrum`/`Full-Finetuning`\n",
+    "\n",
+    "Here we create a measured mapping of strategy to instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# === Backup sagemaker_code/requirements.txt before %%writefile clobbers it ===\n",
+    "# Always overwrite the .bak so re-running the notebook (or running it after a\n",
+    "# different recipe notebook in the same session) captures the *current* state\n",
+    "# as the restore target. The final cell of this notebook restores from .bak.\n",
+    "import shutil, pathlib\n",
+    "_REQ = pathlib.Path(\"sagemaker_code/requirements.txt\")\n",
+    "_BAK = _REQ.with_suffix(\".txt.bak\")\n",
+    "if _REQ.exists():\n",
+    "    shutil.copy2(_REQ, _BAK)\n",
+    "    print(f\"Backed up {_REQ} -> {_BAK}\")\n",
+    "else:\n",
+    "    print(f\"No {_REQ} to back up; skipping.\")\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "478973cd-bbcd-4d47-9734-79fa1b0e8755",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile sagemaker_code/requirements.txt\n",
+    "# === Qwen 3.5 notebook overrides ===\n",
+    "# Bumps for Qwen 3.5 architecture support. Sibling notebooks override this file\n",
+    "# in their cell 28 too, so re-running them after this notebook is harmless.\n",
+    "#\n",
+    "# Why each bump:\n",
+    "#   transformers 5.2.0 \u2014 qwen3_5 architecture not in 4.x\n",
+    "#   peft 0.18.1        \u2014 0.17 imports HybridCache (removed in transformers 5.x)\n",
+    "#   bitsandbytes 0.49.2 \u2014 first version with a CUDA 13.0 binary\n",
+    "#   liger-kernel 0.7.0 \u2014 same HybridCache compatibility as peft\n",
+    "#\n",
+    "transformers==5.2.0\n",
+    "peft==0.18.1\n",
+    "accelerate==1.11.0\n",
+    "bitsandbytes==0.49.2\n",
+    "datasets==4.0.0\n",
+    "deepspeed==0.17.5\n",
+    "hf-transfer==0.1.8\n",
+    "hf_xet\n",
+    "liger-kernel==0.7.0\n",
+    "lm-eval[api]==0.4.9\n",
+    "kernels>=0.9.0\n",
+    "mlflow\n",
+    "Pillow\n",
+    "soundfile\n",
+    "safetensors>=0.6.2\n",
+    "sagemaker==2.251.1\n",
+    "sagemaker-mlflow==0.1.0\n",
+    "sentencepiece==0.2.0\n",
+    "tokenizers>=0.21.4\n",
+    "triton\n",
+    "trl==0.21.0\n",
+    "tensorboard\n",
+    "psutil\n",
+    "py7zr\n",
+    "git+https://github.com/triton-lang/triton.git@main#subdirectory=python/triton_kernels\n",
+    "poetry\n",
+    "yq\n",
+    "psutil\n",
+    "nvidia-ml-py\n",
+    "pyrsmi\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f51158a9-b291-4af8-bcda-362a1dfa7db3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === Choose strategy: QLoRA (4-bit) or Full fine-tuning ===\n",
+    "STRATEGY = \"peft-qlora\"  # one of: \"peft-qlora\", \"full\"\n",
+    "\n",
+    "if STRATEGY == \"peft-qlora\":\n",
+    "    args = [\n",
+    "        \"--config\",\n",
+    "        f\"hf_recipes/Qwen/{MODEL_ID.split('/')[-1]}--vanilla-peft-qlora.yaml\",\n",
+    "    ]\n",
+    "    training_instance_type = \"ml.g5.2xlarge\"\n",
+    "elif STRATEGY == \"full\":\n",
+    "    args = [\n",
+    "        \"--config\",\n",
+    "        f\"hf_recipes/Qwen/{MODEL_ID.split('/')[-1]}--vanilla-full.yaml\",\n",
+    "    ]\n",
+    "    training_instance_type = \"ml.g7e.12xlarge\"\n",
+    "else:\n",
+    "    raise ValueError(f\"unknown STRATEGY: {STRATEGY}\")\n",
+    "\n",
+    "training_instance_count = 1\n",
+    "print(f\"Strategy: {STRATEGY} | Instance: {training_instance_type}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5eefe7b2-f29c-4d17-969b-660c7cf7386f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pytorch_image_uri = sagemaker.image_uris.retrieve(\n",
+    "    framework=\"pytorch\",\n",
+    "    region=sess.boto_session.region_name,\n",
+    "    version=\"2.7.1\",\n",
+    "    instance_type=training_instance_type,\n",
+    "    image_scope=\"training\",\n",
+    ")\n",
+    "print(f\"Using image: {pytorch_image_uri}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9308684f-4d04-4146-b6a5-3527d07039b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source_code = SourceCode(\n",
+    "    source_dir=\"./sagemaker_code\",\n",
+    "    command=f\"bash sm_accelerate_train.sh {' '.join(args)}\",\n",
+    ")\n",
+    "\n",
+    "compute_configs = Compute(\n",
+    "    instance_type=training_instance_type,\n",
+    "    instance_count=training_instance_count,\n",
+    "    keep_alive_period_in_seconds=1800,\n",
+    "    volume_size_in_gb=300\n",
+    ")\n",
+    "\n",
+    "base_job_name = f\"{job_name}-finetune\"\n",
+    "output_path = f\"s3://{sess.default_bucket()}/{base_job_name}\"\n",
+    "\n",
+    "model_trainer = ModelTrainer(\n",
+    "    training_image=pytorch_image_uri,\n",
+    "    source_code=source_code,\n",
+    "    base_job_name=base_job_name,\n",
+    "    compute=compute_configs,\n",
+    "    stopping_condition=StoppingCondition(max_runtime_in_seconds=18000),\n",
+    "    output_data_config=OutputDataConfig(\n",
+    "        s3_output_path=output_path,\n",
+    "    ),\n",
+    "    checkpoint_config=CheckpointConfig(\n",
+    "        s3_uri=os.path.join(\n",
+    "            output_path,\n",
+    "            dataset_name.replace('/', '--').replace('.', '-'), \n",
+    "            job_name,\n",
+    "            \"checkpoints\"\n",
+    "        ), \n",
+    "        local_path=\"/opt/ml/checkpoints\"\n",
+    "    ),\n",
+    "    role=role,\n",
+    "    environment=training_env\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f2699f9-03aa-467e-98d0-8259bcab1308",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_trainer.train(\n",
+    "    input_data_config=[\n",
+    "        InputData(\n",
+    "            channel_name=\"training\",\n",
+    "            data_source=uploaded_s3_uri,  \n",
+    "        )\n",
+    "    ], \n",
+    "    wait=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Cleanup \u2014 restore upstream `requirements.txt`\n",
+    "\n",
+    "Run this cell after the training job is queued / completed to leave `sagemaker_code/` exactly as it was before this notebook ran.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# === Restore upstream requirements.txt from .bak ===\n",
+    "import pathlib, shutil\n",
+    "_BAK = pathlib.Path(\"sagemaker_code/requirements.txt.bak\")\n",
+    "if _BAK.exists():\n",
+    "    target = _BAK.with_suffix(\"\")\n",
+    "    shutil.copy2(_BAK, target)\n",
+    "    _BAK.unlink()\n",
+    "    print(f\"Restored {target} from .bak\")\n",
+    "else:\n",
+    "    print(\"No backup found; nothing to restore.\")\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Where to find the trained adapter / model\n",
+    "\n",
+    "After training completes, artifacts land at `s3://<bucket>/<job-name>/output/model.tar.gz`.\n",
+    "\n",
+    "| Strategy | Tarball contents |\n",
+    "|---|---|\n",
+    "| QLoRA | `Qwen/<model>/peft_adapter/` containing standard PEFT files (`adapter_config.json`, `adapter_model.safetensors`, tokenizer, chat template) \u2014 vLLM `--enable-lora`, DJL Serving / LMI, and Bedrock all consume it directly |\n",
+    "| Full | Sharded `safetensors` of the merged checkpoint, ready for direct inference deployment |\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/0_model_customization_recipes/supervised_finetuning/finetune--Qwen--Qwen3.5-9B.ipynb
+++ b/0_model_customization_recipes/supervised_finetuning/finetune--Qwen--Qwen3.5-9B.ipynb
@@ -1,0 +1,672 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e60b91a9-7d9c-4c45-be0f-5a224581f644",
+   "metadata": {},
+   "source": [
+    "# \ud83d\ude80 Customize and Deploy `Qwen/Qwen3.5-9B` on Amazon SageMaker AI\n",
+    "---\n",
+    "This notebook fine-tunes **Qwen3.5-9B (Instruct)** (~9 billion (post-trained / Instruct variant)) on Amazon SageMaker Training Jobs using the shared `sagemaker_code/sft.py` driver. Both QLoRA (4-bit) and full fine-tuning are supported via the strategy chooser cell.\n",
+    "\n",
+    "\ud83d\udd17 Model card: [Qwen/Qwen3.5-9B on Hugging Face](https://huggingface.co/Qwen/Qwen3.5-9B)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Validated configurations**:\n",
+    "\n",
+    "| Strategy | Default instance | GPU(s) | Wall clock (typical) |\n",
+    "|---|---|---|---|\n",
+    "| QLoRA (4-bit) | `ml.g5.2xlarge` | 1\u00d7 A10G 24 GB | ~20-30 min |\n",
+    "| Full fine-tuning | `ml.g7e.12xlarge` | 4\u00d7 RTX PRO 6000 Blackwell 384 GB total | ~30-50 min |\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Why this notebook overrides `sagemaker_code/requirements.txt`**\n",
+    "\n",
+    "Qwen 3.5 introduces a new model architecture (`qwen3_5`) that requires `transformers >= 5.2.0`. The shared `requirements.txt` pins `transformers==4.57.0`, so the cell below overrides the file via `%%writefile` (with a backed-up `.bak`, restored by the final cell):\n",
+    "\n",
+    "| Package | Shared default | Required | Why |\n",
+    "|---|---|---|---|\n",
+    "| `transformers` | 4.57.0 | 5.2.0 | `qwen3_5` architecture not in 4.x |\n",
+    "| `peft` | 0.17.0 | 0.18.1 | `HybridCache` removed in transformers 5.x |\n",
+    "| `bitsandbytes` | 0.46.1 | 0.49.2 | First version with a CUDA 13.0 binary |\n",
+    "| `liger-kernel` | 0.6.1 | 0.7.0 | Same `HybridCache` compatibility issue |\n",
+    "\n",
+    "`trl == 0.21.0` and the rest of the toolchain are unchanged \u2014 Qwen 3.5 works with the existing `sft.py` and `merge_adapter_weights.py` without source-code patches.\n",
+    "\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ce40054-610a-4acc-a546-943893f293c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -Uq \"datasets==4.3.0\" \\\n",
+    "    \"sagemaker==2.253.1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b791e72e-82b5-4f8e-a7fe-700e8afdeba5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "import sagemaker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23c673a9-5b9f-47e0-92cf-bb97486b3e1a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "region = boto3.Session().region_name\n",
+    "\n",
+    "sess = sagemaker.Session(boto3.Session(region_name=region))\n",
+    "\n",
+    "sagemaker_session_bucket = None\n",
+    "if sagemaker_session_bucket is None and sess is not None:\n",
+    "    # set to default bucket if a bucket name is not given\n",
+    "    sagemaker_session_bucket = sess.default_bucket()\n",
+    "\n",
+    "role = sagemaker.get_execution_role()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9786901-b012-41ff-a98a-b16e5f60ec9c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"sagemaker role arn: {role}\")\n",
+    "print(f\"sagemaker bucket: {sess.default_bucket()}\")\n",
+    "print(f\"sagemaker session region: {sess.boto_region_name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "565528c2-9f7d-47aa-bfca-6c35c9112f07",
+   "metadata": {},
+   "source": [
+    "## Data Preparation for Supervised Fine-tuning"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f78bb88-acf9-4cc3-8486-51e03d581b6e",
+   "metadata": {},
+   "source": [
+    "### [Finance-Instruct-500k](https://huggingface.co/datasets/Josephgflowers/Finance-Instruct-500k)\n",
+    "\n",
+    "**Finance-Instruct-500k** is a large-scale dataset with about **518,000 entries** focused on the financial domain. It spans topics such as investments, banking, markets, accounting, and corporate finance, offering a wide variety of instruction\u2013response examples.\n",
+    "\n",
+    "**Data Format & Structure**:\n",
+    "- Distributed in **JSON** format, with simple conversion to Parquet.  \n",
+    "- Contains a single `train` split with ~518k records.  \n",
+    "- Each record includes:  \n",
+    "  - `system` \u2013 context or metadata for the task  \n",
+    "  - `user` \u2013 the financial prompt or query  \n",
+    "  - `assistant` \u2013 the corresponding response  \n",
+    "\n",
+    "**License**: Released under the **Apache-2.0** license.  \n",
+    "\n",
+    "**Applications**:\n",
+    "\n",
+    "The dataset can support finance-focused tasks such as:  \n",
+    "- Financial question answering  \n",
+    "- Market and investment analysis  \n",
+    "- Topic and sentiment classification  \n",
+    "- Financial entity extraction and document understanding  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "745fda33-d065-45c3-b69a-d17a041c3b07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import json\n",
+    "import pprint\n",
+    "from tqdm import tqdm\n",
+    "from datasets import load_dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18e4a8e2-24dc-4e1f-be35-1aed9d6212dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_parent_path = os.path.join(os.getcwd(), \"tmp_cache_local_dataset\")\n",
+    "os.makedirs(dataset_parent_path, exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b18688b5-fc28-4c6c-a1ea-1250dc71acc4",
+   "metadata": {},
+   "source": [
+    "**Preparing Your Dataset in `messages` format**\n",
+    "\n",
+    "This section walks you through creating a conversation-style dataset\u2014the required `messages` format\u2014for directly training LLMs using SageMaker AI.\n",
+    "\n",
+    "**What Is the `messages` Format?**\n",
+    "\n",
+    "The `messages` format structures instances as chat-like exchanges, wrapping each conversation turn into a role-labeled JSON array. It\u2019s widely used by frameworks like TRL.\n",
+    "\n",
+    "Example entry:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "  \"messages\": [\n",
+    "    { \"role\": \"system\", \"content\": \"You are a helpful assistant.\" },\n",
+    "    { \"role\": \"user\", \"content\": \"How do I bake sourdough?\" },\n",
+    "    { \"role\": \"assistant\", \"content\": \"First, you need to create a starter by...\" }\n",
+    "  ]\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "992e9ac9-2b9f-49de-a932-91b459283840",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_name = \"Josephgflowers/Finance-Instruct-500k\"\n",
+    "dataset = load_dataset(dataset_name, split=\"train[:1000]\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9bdbf5d1-9e12-4ee3-985a-713d84c98560",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "pprint.pp(dataset[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "259415f8-cb2a-47c5-bc91-293f4ac704ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"total number of fine-tunable samples: {len(dataset)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85fa8b14-3316-49a4-b67e-aca9d9be6498",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def convert_to_messages(row):\n",
+    "    system_content = \"You are a financial reasoning assistant. Read the user's query, restate the key data, and solve step by step. Show calculations clearly, explain any rounding or adjustments, and present the final answer in a concise and professional manner.\"\n",
+    "    user_content = row[\"user\"]\n",
+    "    assistant_content = row[\"assistant\"]\n",
+    "\n",
+    "    return {\n",
+    "        \"messages\": [\n",
+    "            {\"role\": \"system\", \"content\": system_content},\n",
+    "            {\"role\": \"user\", \"content\": user_content},\n",
+    "            {\"role\": \"assistant\", \"content\": assistant_content},\n",
+    "        ]\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "dataset = dataset.map(convert_to_messages, remove_columns=dataset.column_names)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "434df993-5310-45c4-bb81-0e2fe5181e1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_filename = os.path.join(dataset_parent_path, f\"{dataset_name.replace('/', '--').replace('.', '-')}.jsonl\")\n",
+    "dataset.to_json(dataset_filename, lines=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72c3276e-1cee-40f4-9477-c596863f809e",
+   "metadata": {},
+   "source": [
+    "#### Upload file to S3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ee8f5ea-1d2e-4271-80c0-f984c0e275f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.s3 import S3Uploader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9094fda7-f723-49bc-a2a3-d5ab88ae849d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_s3_uri = f\"s3://{sess.default_bucket()}/dataset\"\n",
+    "\n",
+    "uploaded_s3_uri = S3Uploader.upload(\n",
+    "    local_path=dataset_filename,\n",
+    "    desired_s3_uri=data_s3_uri\n",
+    ")\n",
+    "print(f\"Uploaded {dataset_filename} to > {uploaded_s3_uri}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d28ff7ed-ae76-45ed-9fae-489394738e7e",
+   "metadata": {},
+   "source": [
+    "## Fine-Tune LLMs using SageMaker AI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d7287b14-f829-4256-8839-2b573bc32ee6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "from sagemaker.modules.configs import (\n",
+    "    CheckpointConfig,\n",
+    "    Compute,\n",
+    "    OutputDataConfig,\n",
+    "    SourceCode,\n",
+    "    StoppingCondition,\n",
+    ")\n",
+    "from sagemaker.modules.configs import InputData\n",
+    "from sagemaker.modules.train import ModelTrainer\n",
+    "from getpass import getpass\n",
+    "import yaml\n",
+    "from jinja2 import Template"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8622086a-d844-4475-8433-59ee899a83cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MODEL_ID = \"Qwen/Qwen3.5-9B\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e623397c-7206-4276-9328-b32dd0c1c34f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hf_token = getpass()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f056b30-bb07-4217-8373-2f7a09e4e412",
+   "metadata": {},
+   "source": [
+    "### Training using `PyTorch` Estimator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "227b5c53-404d-4ae2-8d66-b1066a61522a",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "**Observability**: SageMaker AI has [SageMaker MLflow](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) which enables you to accelerate generative AI by making it easier to track experiments and monitor performance of models and AI applications using a single tool.\n",
+    "\n",
+    "You can choose to include MLflow as a part of your training workflow to track your model fine-tuning metrics in realtime by simply specifying a **mlflow** tracking arn.\n",
+    "\n",
+    "Optionally you can also report to : **tensorboard**, **wandb**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f168326f-6e19-45c7-b052-f1587fe71edf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MLFLOW_TRACKING_SERVER_ARN = \"arn:aws:sagemaker:us-east-1:XXXXXYYYYYZZ:mlflow-tracking-server/<name>\" # or None\n",
+    "\n",
+    "if MLFLOW_TRACKING_SERVER_ARN:\n",
+    "    reports_to = \"mlflow\"\n",
+    "else:\n",
+    "    reports_to = \"tensorboard\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e6925c3-46d3-4435-8198-a21ab67da65e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "job_name = MODEL_ID.replace('/', '--').replace('.', '-')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c36d5488-c0d0-4336-b2c8-df3632d2c3a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if MLFLOW_TRACKING_SERVER_ARN:\n",
+    "    training_env = {\n",
+    "        # mlflow tracking metrics\n",
+    "        \"MLFLOW_EXPERIMENT_NAME\": f\"{job_name}-exp\",\n",
+    "        \"MLFLOW_TAGS\": json.dumps(\n",
+    "            {\n",
+    "                \"source.job\": \"sm-training-jobs\", \n",
+    "                \"source.type\": \"sft\", \n",
+    "                \"source.framework\": \"pytorch\"\n",
+    "            }\n",
+    "        ),\n",
+    "        \"MLFLOW_TRACKING_URI\": MLFLOW_TRACKING_SERVER_ARN,\n",
+    "        \"MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING\": \"true\",\n",
+    "        # non tracking metrics - enabled\n",
+    "        \"HF_TOKEN\": hf_token,\n",
+    "        \"FI_EFA_USE_DEVICE_RDMA\": \"1\",\n",
+    "        \"NCCL_DEBUG\": \"INFO\",\n",
+    "        \"NCCL_SOCKET_IFNAME\": \"eth0\",\n",
+    "        \"FI_PROVIDER\": \"efa\",\n",
+    "        \"NCCL_PROTO\": \"simple\",\n",
+    "        \"NCCL_NET_GDR_LEVEL\": \"5\"\n",
+    "    }\n",
+    "else:\n",
+    "    training_env = {\n",
+    "        # non tracking metrics\n",
+    "        \"HF_TOKEN\": hf_token,\n",
+    "        \"FI_EFA_USE_DEVICE_RDMA\": \"1\",\n",
+    "        \"NCCL_DEBUG\": \"INFO\",\n",
+    "        \"NCCL_SOCKET_IFNAME\": \"eth0\",\n",
+    "        \"FI_PROVIDER\": \"efa\",\n",
+    "        \"NCCL_PROTO\": \"simple\",\n",
+    "        \"NCCL_NET_GDR_LEVEL\": \"5\"\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19e6ff10-4311-4bbb-bd60-dd8bcefa039d",
+   "metadata": {},
+   "source": [
+    "#### Training strategy - Choose between: `PeFT`/`Spectrum`/`Full-Finetuning`\n",
+    "\n",
+    "Here we create a measured mapping of strategy to instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# === Backup sagemaker_code/requirements.txt before %%writefile clobbers it ===\n",
+    "# Always overwrite the .bak so re-running the notebook (or running it after a\n",
+    "# different recipe notebook in the same session) captures the *current* state\n",
+    "# as the restore target. The final cell of this notebook restores from .bak.\n",
+    "import shutil, pathlib\n",
+    "_REQ = pathlib.Path(\"sagemaker_code/requirements.txt\")\n",
+    "_BAK = _REQ.with_suffix(\".txt.bak\")\n",
+    "if _REQ.exists():\n",
+    "    shutil.copy2(_REQ, _BAK)\n",
+    "    print(f\"Backed up {_REQ} -> {_BAK}\")\n",
+    "else:\n",
+    "    print(f\"No {_REQ} to back up; skipping.\")\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "478973cd-bbcd-4d47-9734-79fa1b0e8755",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile sagemaker_code/requirements.txt\n",
+    "# === Qwen 3.5 notebook overrides ===\n",
+    "# Bumps for Qwen 3.5 architecture support. Sibling notebooks override this file\n",
+    "# in their cell 28 too, so re-running them after this notebook is harmless.\n",
+    "#\n",
+    "# Why each bump:\n",
+    "#   transformers 5.2.0 \u2014 qwen3_5 architecture not in 4.x\n",
+    "#   peft 0.18.1        \u2014 0.17 imports HybridCache (removed in transformers 5.x)\n",
+    "#   bitsandbytes 0.49.2 \u2014 first version with a CUDA 13.0 binary\n",
+    "#   liger-kernel 0.7.0 \u2014 same HybridCache compatibility as peft\n",
+    "#\n",
+    "transformers==5.2.0\n",
+    "peft==0.18.1\n",
+    "accelerate==1.11.0\n",
+    "bitsandbytes==0.49.2\n",
+    "datasets==4.0.0\n",
+    "deepspeed==0.17.5\n",
+    "hf-transfer==0.1.8\n",
+    "hf_xet\n",
+    "liger-kernel==0.7.0\n",
+    "lm-eval[api]==0.4.9\n",
+    "kernels>=0.9.0\n",
+    "mlflow\n",
+    "Pillow\n",
+    "soundfile\n",
+    "safetensors>=0.6.2\n",
+    "sagemaker==2.251.1\n",
+    "sagemaker-mlflow==0.1.0\n",
+    "sentencepiece==0.2.0\n",
+    "tokenizers>=0.21.4\n",
+    "triton\n",
+    "trl==0.21.0\n",
+    "tensorboard\n",
+    "psutil\n",
+    "py7zr\n",
+    "git+https://github.com/triton-lang/triton.git@main#subdirectory=python/triton_kernels\n",
+    "poetry\n",
+    "yq\n",
+    "psutil\n",
+    "nvidia-ml-py\n",
+    "pyrsmi\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f51158a9-b291-4af8-bcda-362a1dfa7db3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === Choose strategy: QLoRA (4-bit) or Full fine-tuning ===\n",
+    "STRATEGY = \"peft-qlora\"  # one of: \"peft-qlora\", \"full\"\n",
+    "\n",
+    "if STRATEGY == \"peft-qlora\":\n",
+    "    args = [\n",
+    "        \"--config\",\n",
+    "        f\"hf_recipes/Qwen/{MODEL_ID.split('/')[-1]}--vanilla-peft-qlora.yaml\",\n",
+    "    ]\n",
+    "    training_instance_type = \"ml.g5.2xlarge\"\n",
+    "elif STRATEGY == \"full\":\n",
+    "    args = [\n",
+    "        \"--config\",\n",
+    "        f\"hf_recipes/Qwen/{MODEL_ID.split('/')[-1]}--vanilla-full.yaml\",\n",
+    "    ]\n",
+    "    training_instance_type = \"ml.g7e.12xlarge\"\n",
+    "else:\n",
+    "    raise ValueError(f\"unknown STRATEGY: {STRATEGY}\")\n",
+    "\n",
+    "training_instance_count = 1\n",
+    "print(f\"Strategy: {STRATEGY} | Instance: {training_instance_type}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5eefe7b2-f29c-4d17-969b-660c7cf7386f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pytorch_image_uri = sagemaker.image_uris.retrieve(\n",
+    "    framework=\"pytorch\",\n",
+    "    region=sess.boto_session.region_name,\n",
+    "    version=\"2.7.1\",\n",
+    "    instance_type=training_instance_type,\n",
+    "    image_scope=\"training\",\n",
+    ")\n",
+    "print(f\"Using image: {pytorch_image_uri}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9308684f-4d04-4146-b6a5-3527d07039b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source_code = SourceCode(\n",
+    "    source_dir=\"./sagemaker_code\",\n",
+    "    command=f\"bash sm_accelerate_train.sh {' '.join(args)}\",\n",
+    ")\n",
+    "\n",
+    "compute_configs = Compute(\n",
+    "    instance_type=training_instance_type,\n",
+    "    instance_count=training_instance_count,\n",
+    "    keep_alive_period_in_seconds=1800,\n",
+    "    volume_size_in_gb=300\n",
+    ")\n",
+    "\n",
+    "base_job_name = f\"{job_name}-finetune\"\n",
+    "output_path = f\"s3://{sess.default_bucket()}/{base_job_name}\"\n",
+    "\n",
+    "model_trainer = ModelTrainer(\n",
+    "    training_image=pytorch_image_uri,\n",
+    "    source_code=source_code,\n",
+    "    base_job_name=base_job_name,\n",
+    "    compute=compute_configs,\n",
+    "    stopping_condition=StoppingCondition(max_runtime_in_seconds=18000),\n",
+    "    output_data_config=OutputDataConfig(\n",
+    "        s3_output_path=output_path,\n",
+    "    ),\n",
+    "    checkpoint_config=CheckpointConfig(\n",
+    "        s3_uri=os.path.join(\n",
+    "            output_path,\n",
+    "            dataset_name.replace('/', '--').replace('.', '-'), \n",
+    "            job_name,\n",
+    "            \"checkpoints\"\n",
+    "        ), \n",
+    "        local_path=\"/opt/ml/checkpoints\"\n",
+    "    ),\n",
+    "    role=role,\n",
+    "    environment=training_env\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f2699f9-03aa-467e-98d0-8259bcab1308",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_trainer.train(\n",
+    "    input_data_config=[\n",
+    "        InputData(\n",
+    "            channel_name=\"training\",\n",
+    "            data_source=uploaded_s3_uri,  \n",
+    "        )\n",
+    "    ], \n",
+    "    wait=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Cleanup \u2014 restore upstream `requirements.txt`\n",
+    "\n",
+    "Run this cell after the training job is queued / completed to leave `sagemaker_code/` exactly as it was before this notebook ran.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# === Restore upstream requirements.txt from .bak ===\n",
+    "import pathlib, shutil\n",
+    "_BAK = pathlib.Path(\"sagemaker_code/requirements.txt.bak\")\n",
+    "if _BAK.exists():\n",
+    "    target = _BAK.with_suffix(\"\")\n",
+    "    shutil.copy2(_BAK, target)\n",
+    "    _BAK.unlink()\n",
+    "    print(f\"Restored {target} from .bak\")\n",
+    "else:\n",
+    "    print(\"No backup found; nothing to restore.\")\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Where to find the trained adapter / model\n",
+    "\n",
+    "After training completes, artifacts land at `s3://<bucket>/<job-name>/output/model.tar.gz`.\n",
+    "\n",
+    "| Strategy | Tarball contents |\n",
+    "|---|---|\n",
+    "| QLoRA | `Qwen/<model>/peft_adapter/` containing standard PEFT files (`adapter_config.json`, `adapter_model.safetensors`, tokenizer, chat template) \u2014 vLLM `--enable-lora`, DJL Serving / LMI, and Bedrock all consume it directly |\n",
+    "| Full | Sharded `safetensors` of the merged checkpoint, ready for direct inference deployment |\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/0_model_customization_recipes/supervised_finetuning/sagemaker_code/hf_recipes/Qwen/Qwen3.5-4B--vanilla-full.yaml
+++ b/0_model_customization_recipes/supervised_finetuning/sagemaker_code/hf_recipes/Qwen/Qwen3.5-4B--vanilla-full.yaml
@@ -1,0 +1,38 @@
+# Model arguments
+model_name_or_path: Qwen/Qwen3.5-4B
+tokenizer_name_or_path: Qwen/Qwen3.5-4B
+model_revision: main
+torch_dtype: bfloat16
+attn_implementation: sdpa
+use_liger: false
+bf16: true
+tf32: false
+output_dir: /opt/ml/checkpoints/Qwen/Qwen3.5-4B/full-finetuning/
+
+# Dataset arguments
+dataset_id_or_path: /opt/ml/input/data/training/Josephgflowers--Finance-Instruct-500k.jsonl
+max_seq_length: 4096
+packing: false
+
+# Modality type
+modality_type: "text"
+
+# Training arguments
+num_train_epochs: 1
+per_device_train_batch_size: 2
+gradient_accumulation_steps: 2
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: true
+learning_rate: 1.0e-4
+lr_scheduler_type: cosine
+warmup_ratio: 0.1
+
+# Logging arguments
+logging_strategy: steps
+logging_steps: 1
+report_to:
+- tensorboard
+run_name: Qwen3.5-4B-full-Josephgflowers--Finance-Instruct-500k
+save_strategy: epoch
+seed: 42

--- a/0_model_customization_recipes/supervised_finetuning/sagemaker_code/hf_recipes/Qwen/Qwen3.5-4B--vanilla-peft-qlora.yaml
+++ b/0_model_customization_recipes/supervised_finetuning/sagemaker_code/hf_recipes/Qwen/Qwen3.5-4B--vanilla-peft-qlora.yaml
@@ -1,0 +1,45 @@
+# Model arguments
+model_name_or_path: Qwen/Qwen3.5-4B
+tokenizer_name_or_path: Qwen/Qwen3.5-4B
+model_revision: main
+torch_dtype: bfloat16
+attn_implementation: sdpa
+use_liger: false
+bf16: true
+tf32: false
+output_dir: /opt/ml/checkpoints/Qwen/Qwen3.5-4B/peft-qlora/
+
+# Dataset arguments
+dataset_id_or_path: /opt/ml/input/data/training/Josephgflowers--Finance-Instruct-500k.jsonl
+max_seq_length: 4096
+packing: false
+
+# Modality type
+modality_type: "text"
+
+# LoRA arguments
+use_peft: true
+load_in_4bit: true
+lora_target_modules: ["q_proj", "k_proj", "v_proj", "o_proj"]
+lora_r: 8
+lora_alpha: 16
+
+# Training arguments
+num_train_epochs: 1
+per_device_train_batch_size: 2
+gradient_accumulation_steps: 2
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: true
+learning_rate: 1.0e-4
+lr_scheduler_type: cosine
+warmup_ratio: 0.1
+
+# Logging arguments
+logging_strategy: steps
+logging_steps: 2
+report_to:
+- tensorboard
+run_name: Qwen3.5-4B-peft-qlora-Josephgflowers--Finance-Instruct-500k
+save_strategy: epoch
+seed: 42

--- a/0_model_customization_recipes/supervised_finetuning/sagemaker_code/hf_recipes/Qwen/Qwen3.5-4B-Base--vanilla-full.yaml
+++ b/0_model_customization_recipes/supervised_finetuning/sagemaker_code/hf_recipes/Qwen/Qwen3.5-4B-Base--vanilla-full.yaml
@@ -1,0 +1,38 @@
+# Model arguments
+model_name_or_path: Qwen/Qwen3.5-4B-Base
+tokenizer_name_or_path: Qwen/Qwen3.5-4B-Base
+model_revision: main
+torch_dtype: bfloat16
+attn_implementation: sdpa
+use_liger: false
+bf16: true
+tf32: false
+output_dir: /opt/ml/checkpoints/Qwen/Qwen3.5-4B-Base/full-finetuning/
+
+# Dataset arguments
+dataset_id_or_path: /opt/ml/input/data/training/Josephgflowers--Finance-Instruct-500k.jsonl
+max_seq_length: 4096
+packing: false
+
+# Modality type
+modality_type: "text"
+
+# Training arguments
+num_train_epochs: 1
+per_device_train_batch_size: 2
+gradient_accumulation_steps: 2
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: true
+learning_rate: 1.0e-4
+lr_scheduler_type: cosine
+warmup_ratio: 0.1
+
+# Logging arguments
+logging_strategy: steps
+logging_steps: 1
+report_to:
+- tensorboard
+run_name: Qwen3.5-4B-Base-full-Josephgflowers--Finance-Instruct-500k
+save_strategy: epoch
+seed: 42

--- a/0_model_customization_recipes/supervised_finetuning/sagemaker_code/hf_recipes/Qwen/Qwen3.5-4B-Base--vanilla-peft-qlora.yaml
+++ b/0_model_customization_recipes/supervised_finetuning/sagemaker_code/hf_recipes/Qwen/Qwen3.5-4B-Base--vanilla-peft-qlora.yaml
@@ -1,0 +1,45 @@
+# Model arguments
+model_name_or_path: Qwen/Qwen3.5-4B-Base
+tokenizer_name_or_path: Qwen/Qwen3.5-4B-Base
+model_revision: main
+torch_dtype: bfloat16
+attn_implementation: sdpa
+use_liger: false
+bf16: true
+tf32: false
+output_dir: /opt/ml/checkpoints/Qwen/Qwen3.5-4B-Base/peft-qlora/
+
+# Dataset arguments
+dataset_id_or_path: /opt/ml/input/data/training/Josephgflowers--Finance-Instruct-500k.jsonl
+max_seq_length: 4096
+packing: false
+
+# Modality type
+modality_type: "text"
+
+# LoRA arguments
+use_peft: true
+load_in_4bit: true
+lora_target_modules: ["q_proj", "k_proj", "v_proj", "o_proj"]
+lora_r: 8
+lora_alpha: 16
+
+# Training arguments
+num_train_epochs: 1
+per_device_train_batch_size: 2
+gradient_accumulation_steps: 2
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: true
+learning_rate: 1.0e-4
+lr_scheduler_type: cosine
+warmup_ratio: 0.1
+
+# Logging arguments
+logging_strategy: steps
+logging_steps: 2
+report_to:
+- tensorboard
+run_name: Qwen3.5-4B-Base-peft-qlora-Josephgflowers--Finance-Instruct-500k
+save_strategy: epoch
+seed: 42

--- a/0_model_customization_recipes/supervised_finetuning/sagemaker_code/hf_recipes/Qwen/Qwen3.5-9B--vanilla-full.yaml
+++ b/0_model_customization_recipes/supervised_finetuning/sagemaker_code/hf_recipes/Qwen/Qwen3.5-9B--vanilla-full.yaml
@@ -1,0 +1,38 @@
+# Model arguments
+model_name_or_path: Qwen/Qwen3.5-9B
+tokenizer_name_or_path: Qwen/Qwen3.5-9B
+model_revision: main
+torch_dtype: bfloat16
+attn_implementation: sdpa
+use_liger: false
+bf16: true
+tf32: false
+output_dir: /opt/ml/checkpoints/Qwen/Qwen3.5-9B/full-finetuning/
+
+# Dataset arguments
+dataset_id_or_path: /opt/ml/input/data/training/Josephgflowers--Finance-Instruct-500k.jsonl
+max_seq_length: 4096
+packing: false
+
+# Modality type
+modality_type: "text"
+
+# Training arguments
+num_train_epochs: 1
+per_device_train_batch_size: 2
+gradient_accumulation_steps: 2
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: true
+learning_rate: 1.0e-4
+lr_scheduler_type: cosine
+warmup_ratio: 0.1
+
+# Logging arguments
+logging_strategy: steps
+logging_steps: 1
+report_to:
+- tensorboard
+run_name: Qwen3.5-9B-full-Josephgflowers--Finance-Instruct-500k
+save_strategy: epoch
+seed: 42

--- a/0_model_customization_recipes/supervised_finetuning/sagemaker_code/hf_recipes/Qwen/Qwen3.5-9B--vanilla-peft-qlora.yaml
+++ b/0_model_customization_recipes/supervised_finetuning/sagemaker_code/hf_recipes/Qwen/Qwen3.5-9B--vanilla-peft-qlora.yaml
@@ -1,0 +1,45 @@
+# Model arguments
+model_name_or_path: Qwen/Qwen3.5-9B
+tokenizer_name_or_path: Qwen/Qwen3.5-9B
+model_revision: main
+torch_dtype: bfloat16
+attn_implementation: sdpa
+use_liger: false
+bf16: true
+tf32: false
+output_dir: /opt/ml/checkpoints/Qwen/Qwen3.5-9B/peft-qlora/
+
+# Dataset arguments
+dataset_id_or_path: /opt/ml/input/data/training/Josephgflowers--Finance-Instruct-500k.jsonl
+max_seq_length: 4096
+packing: false
+
+# Modality type
+modality_type: "text"
+
+# LoRA arguments
+use_peft: true
+load_in_4bit: true
+lora_target_modules: ["q_proj", "k_proj", "v_proj", "o_proj"]
+lora_r: 8
+lora_alpha: 16
+
+# Training arguments
+num_train_epochs: 1
+per_device_train_batch_size: 2
+gradient_accumulation_steps: 2
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: true
+learning_rate: 1.0e-4
+lr_scheduler_type: cosine
+warmup_ratio: 0.1
+
+# Logging arguments
+logging_strategy: steps
+logging_steps: 2
+report_to:
+- tensorboard
+run_name: Qwen3.5-9B-peft-qlora-Josephgflowers--Finance-Instruct-500k
+save_strategy: epoch
+seed: 42

--- a/0_model_customization_recipes/supervised_finetuning/sagemaker_code/hf_recipes/Qwen/Qwen3.5-9B-Base--vanilla-full.yaml
+++ b/0_model_customization_recipes/supervised_finetuning/sagemaker_code/hf_recipes/Qwen/Qwen3.5-9B-Base--vanilla-full.yaml
@@ -1,0 +1,38 @@
+# Model arguments
+model_name_or_path: Qwen/Qwen3.5-9B-Base
+tokenizer_name_or_path: Qwen/Qwen3.5-9B-Base
+model_revision: main
+torch_dtype: bfloat16
+attn_implementation: sdpa
+use_liger: false
+bf16: true
+tf32: false
+output_dir: /opt/ml/checkpoints/Qwen/Qwen3.5-9B-Base/full-finetuning/
+
+# Dataset arguments
+dataset_id_or_path: /opt/ml/input/data/training/Josephgflowers--Finance-Instruct-500k.jsonl
+max_seq_length: 4096
+packing: false
+
+# Modality type
+modality_type: "text"
+
+# Training arguments
+num_train_epochs: 1
+per_device_train_batch_size: 2
+gradient_accumulation_steps: 2
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: true
+learning_rate: 1.0e-4
+lr_scheduler_type: cosine
+warmup_ratio: 0.1
+
+# Logging arguments
+logging_strategy: steps
+logging_steps: 1
+report_to:
+- tensorboard
+run_name: Qwen3.5-9B-Base-full-Josephgflowers--Finance-Instruct-500k
+save_strategy: epoch
+seed: 42

--- a/0_model_customization_recipes/supervised_finetuning/sagemaker_code/hf_recipes/Qwen/Qwen3.5-9B-Base--vanilla-peft-qlora.yaml
+++ b/0_model_customization_recipes/supervised_finetuning/sagemaker_code/hf_recipes/Qwen/Qwen3.5-9B-Base--vanilla-peft-qlora.yaml
@@ -1,0 +1,45 @@
+# Model arguments
+model_name_or_path: Qwen/Qwen3.5-9B-Base
+tokenizer_name_or_path: Qwen/Qwen3.5-9B-Base
+model_revision: main
+torch_dtype: bfloat16
+attn_implementation: sdpa
+use_liger: false
+bf16: true
+tf32: false
+output_dir: /opt/ml/checkpoints/Qwen/Qwen3.5-9B-Base/peft-qlora/
+
+# Dataset arguments
+dataset_id_or_path: /opt/ml/input/data/training/Josephgflowers--Finance-Instruct-500k.jsonl
+max_seq_length: 4096
+packing: false
+
+# Modality type
+modality_type: "text"
+
+# LoRA arguments
+use_peft: true
+load_in_4bit: true
+lora_target_modules: ["q_proj", "k_proj", "v_proj", "o_proj"]
+lora_r: 8
+lora_alpha: 16
+
+# Training arguments
+num_train_epochs: 1
+per_device_train_batch_size: 2
+gradient_accumulation_steps: 2
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: true
+learning_rate: 1.0e-4
+lr_scheduler_type: cosine
+warmup_ratio: 0.1
+
+# Logging arguments
+logging_strategy: steps
+logging_steps: 2
+report_to:
+- tensorboard
+run_name: Qwen3.5-9B-Base-peft-qlora-Josephgflowers--Finance-Instruct-500k
+save_strategy: epoch
+seed: 42


### PR DESCRIPTION
# Add Qwen 3.5 (4B / 9B, Base / Instruct) to supervised_finetuning recipes

## Summary

Adds four notebooks and eight recipe YAMLs to `0_model_customization_recipes/supervised_finetuning/` for fine-tuning Qwen 3.5 — both Base and post-trained ("Instruct") variants in 4B and 9B sizes. Each notebook supports both QLoRA (4-bit) and full fine-tuning, selectable via a strategy toggle.

| Notebook | Variants covered | QLoRA default | Full default |
|---|---|---|---|
| `finetune--Qwen--Qwen3.5-4B-Base.ipynb` | Pretrained | `ml.g5.2xlarge` (1× A10G 24 GB) | `ml.g7e.2xlarge` (1× RTX PRO 6000 96 GB) |
| `finetune--Qwen--Qwen3.5-4B.ipynb` | Instruct (post-trained) | `ml.g5.2xlarge` | `ml.g7e.2xlarge` |
| `finetune--Qwen--Qwen3.5-9B-Base.ipynb` | Pretrained | `ml.g5.2xlarge` | `ml.g7e.12xlarge` (4× RTX PRO 6000) |
| `finetune--Qwen--Qwen3.5-9B.ipynb` | Instruct | `ml.g5.2xlarge` | `ml.g7e.12xlarge` |

**Naming note**: On HuggingFace, post-trained variants are published as `Qwen/Qwen3.5-{4B,9B}` with **no `-Instruct` suffix** — the `-Base` suffix denotes the pretrained checkpoint. Both share the same `qwen3_5` architecture, so the same DLC and dependency pins apply; only weights and chat template differ.

## What this PR does NOT change

**Zero source code modifications.** No edits to `sagemaker_code/sft.py`, `sagemaker_code/utils/merge_adapter_weights.py`, or `sm_accelerate_train.sh`. Qwen 3.5 works with the existing shared scaffolding as-is.

## What this PR DOES change

- 4 new `finetune--Qwen--Qwen3.5-*.ipynb` notebooks
- 8 new recipe YAMLs under `sagemaker_code/hf_recipes/Qwen/`

Each notebook overrides `sagemaker_code/requirements.txt` via a `%%writefile` cell at job-submit time (with `.bak` backup, restored by the final cell). The override:

| Package | Shared default | Required | Why |
|---|---|---|---|
| `transformers` | 4.57.0 | 5.2.0 | `qwen3_5` architecture not in 4.x |
| `peft` | 0.17.0 | 0.18.1 | `HybridCache` removed in transformers 5.x; 0.17 hardcodes the import |
| `bitsandbytes` | 0.46.1 | 0.49.2 | First version with a CUDA 13.0 binary (DLC ships CUDA 13) |
| `liger-kernel` | 0.6.1 | 0.7.0 | Same `HybridCache` compatibility issue as peft |

`trl == 0.21.0` and the rest of the toolchain are unchanged — the lockstep TRL 1.x bump that Gemma 4 needs is **not** required here, so existing sibling recipes are unaffected.

## Validation

### This PR's smoke tests (us-east-1, 2026-05-22)

Two SageMaker training jobs run from a clean upstream checkout with only this PR's notebooks + YAMLs + the `%%writefile`-applied `requirements.txt`:

| # | Notebook | Strategy | Instance | Status | Billable | Loss |
|---|---|---|---|---|---|---|
| 1 | `finetune--Qwen--Qwen3.5-4B.ipynb` | QLoRA | `ml.g5.2xlarge` | Completed | 688 s | 1.66 → 1.41 |
| 2 | `finetune--Qwen--Qwen3.5-4B-Base.ipynb` | QLoRA | `ml.g5.2xlarge` | Completed | 471 s | 1.57 → 1.41 |

Both jobs trained 20 steps over 100 rows of `Josephgflowers/Finance-Instruct-500k`, saved a PEFT adapter, and ran the upstream `merge_adapter_weights.py` to completion (the merge step works for Qwen 3.5 — no Gemma-4-style skip needed).

### Reference-repo validation matrix

All eight recipe × instance combinations have additionally been validated end-to-end with real SageMaker training jobs in the [reference repo](https://github.com/dgallitelli/qwen35-sft-sagemaker). Highlights:

| # | Variant | Strategy | Instance | GPU(s) | Billable |
|---|---|---|---|---|---|
| T1 | 4B Instruct | QLoRA | `ml.g5.2xlarge` | 1× A10G 24 GB | ~21 min |
| T2 | 4B Base | Full SFT | `ml.g7e.2xlarge` | 1× RTX PRO 6000 96 GB | ~29 min |
| T3 | 4B Instruct | Full SFT | `ml.g7e.2xlarge` | 1× RTX PRO 6000 96 GB | ~30 min |
| T4 | 9B Base | Full SFT | `ml.g7e.12xlarge` | 4× RTX PRO 6000 (384 GB total) | ~49 min |
| T5 | 9B Instruct | Full SFT | `ml.g7e.12xlarge` | 4× RTX PRO 6000 (384 GB total) | ~46 min |
| T6 | 9B Instruct | QLoRA | `ml.g5.2xlarge` | 1× A10G 24 GB | ~28 min |
| T7 | 9B Instruct | QLoRA | `ml.g6e.2xlarge` | 1× L40S 48 GB | ~22 min |

QLoRA recipes also validated portable across `ml.g5.2xlarge` / `ml.g6.4xlarge` / `ml.g7e.2xlarge` without any recipe changes.

## Rationale

Qwen 3.5 has been generally available on Hugging Face for several months and is a strong general-purpose model that customers ask about regularly. The `qwen3_5` architecture isn't in `transformers 4.57` (the shared `requirements.txt` pin), and that single bump cascades to `peft` / `bitsandbytes` / `liger-kernel` — but none of the cascade reaches `trl` or the source code, so the change is fully contained in `requirements.txt`.

Submitting this as a notebook-only PR for now (matching the precedent of the Gemma 4 recipe submitted earlier today) so reviewers can merge it without touching shared code or other recipes. If `requirements.txt` is bumped repo-wide in a future PR, the `%%writefile` cell becomes a no-op — the notebook continues to work without change.

## Files added

```
0_model_customization_recipes/supervised_finetuning/
├── finetune--Qwen--Qwen3.5-4B-Base.ipynb
├── finetune--Qwen--Qwen3.5-4B.ipynb
├── finetune--Qwen--Qwen3.5-9B-Base.ipynb
├── finetune--Qwen--Qwen3.5-9B.ipynb
└── sagemaker_code/hf_recipes/Qwen/
    ├── Qwen3.5-4B-Base--vanilla-peft-qlora.yaml
    ├── Qwen3.5-4B-Base--vanilla-full.yaml
    ├── Qwen3.5-4B--vanilla-peft-qlora.yaml
    ├── Qwen3.5-4B--vanilla-full.yaml
    ├── Qwen3.5-9B-Base--vanilla-peft-qlora.yaml
    ├── Qwen3.5-9B-Base--vanilla-full.yaml
    ├── Qwen3.5-9B--vanilla-peft-qlora.yaml
    └── Qwen3.5-9B--vanilla-full.yaml
```
